### PR TITLE
Rename Parameter to MySqlParameter

### DIFF
--- a/src/main/java/io/asyncer/r2dbc/mysql/Binding.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/Binding.java
@@ -22,27 +22,27 @@ import io.asyncer.r2dbc.mysql.message.client.PreparedTextQueryMessage;
 import java.util.Arrays;
 
 /**
- * A collection of {@link Parameter} for one bind invocation of a parametrized statement.
+ * A collection of {@link MySqlParameter} for one bind invocation of a parametrized statement.
  *
  * @see ParametrizedStatementSupport
  */
 final class Binding {
 
-    private static final Parameter[] EMPTY_VALUES = { };
+    private static final MySqlParameter[] EMPTY_VALUES = { };
 
-    private final Parameter[] values;
+    private final MySqlParameter[] values;
 
     Binding(int length) {
-        this.values = length == 0 ? EMPTY_VALUES : new Parameter[length];
+        this.values = length == 0 ? EMPTY_VALUES : new MySqlParameter[length];
     }
 
     /**
-     * Add a {@link Parameter} to the binding.
+     * Add a {@link MySqlParameter} to the binding.
      *
-     * @param index the index of the {@link Parameter}
-     * @param value the {@link Parameter} from {@link PrepareParametrizedStatement}
+     * @param index the index of the {@link MySqlParameter}
+     * @param value the {@link MySqlParameter} from {@link PrepareParametrizedStatement}
      */
-    void add(int index, Parameter value) {
+    void add(int index, MySqlParameter value) {
         if (index < 0 || index >= this.values.length) {
             throw new IndexOutOfBoundsException("Index: " + index + ", length: " + this.values.length);
         }
@@ -80,7 +80,7 @@ final class Binding {
     void clear() {
         int size = this.values.length;
         for (int i = 0; i < size; ++i) {
-            Parameter value = this.values[i];
+            MySqlParameter value = this.values[i];
             this.values[i] = null;
 
             if (value != null) {
@@ -125,8 +125,8 @@ final class Binding {
         return String.format("Binding{values=%s}", Arrays.toString(values));
     }
 
-    private Parameter[] drainValues() {
-        Parameter[] results = new Parameter[this.values.length];
+    private MySqlParameter[] drainValues() {
+        MySqlParameter[] results = new MySqlParameter[this.values.length];
 
         System.arraycopy(this.values, 0, results, 0, this.values.length);
         Arrays.fill(this.values, null);

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlParameter.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlParameter.java
@@ -27,7 +27,7 @@ import reactor.core.publisher.Mono;
  * <p>
  * TODO: add ScalarParameter for better performance.
  */
-public interface Parameter extends Disposable {
+public interface MySqlParameter extends Disposable {
 
     /**
      * Note: the {@code null} is processed by built-in codecs.

--- a/src/main/java/io/asyncer/r2dbc/mysql/ParameterIndex.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/ParameterIndex.java
@@ -59,7 +59,7 @@ final class ParameterIndex {
         }
     }
 
-    void bind(Binding binding, Parameter value) {
+    void bind(Binding binding, MySqlParameter value) {
         if (values == null) {
             binding.add(first, value);
         } else {

--- a/src/main/java/io/asyncer/r2dbc/mysql/ParameterWriter.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/ParameterWriter.java
@@ -24,7 +24,7 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 
 /**
- * A writer for {@link Parameter}s of parametrized statements with text-based protocol.
+ * A writer for {@link MySqlParameter}s of parametrized statements with text-based protocol.
  */
 public abstract class ParameterWriter extends Writer {
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/ParametrizedStatementSupport.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/ParametrizedStatementSupport.java
@@ -141,13 +141,13 @@ abstract class ParametrizedStatementSupport extends MySqlStatementSupport {
         return index;
     }
 
-    private void addBinding(int index, Parameter value) {
+    private void addBinding(int index, MySqlParameter value) {
         assertNotExecuted();
 
         this.bindings.getCurrent().add(index, value);
     }
 
-    private void addBinding(ParameterIndex indexes, Parameter value) {
+    private void addBinding(ParameterIndex indexes, MySqlParameter value) {
         assertNotExecuted();
 
         indexes.bind(this.bindings.getCurrent(), value);

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/AbstractLobMySqlParameter.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/AbstractLobMySqlParameter.java
@@ -24,11 +24,11 @@ import reactor.util.Loggers;
 import reactor.util.annotation.Nullable;
 
 /**
- * Base class considers LOB types (i.e. BLOB, CLOB) for {@link AbstractParameter} implementations.
+ * Base class considers LOB types (i.e. BLOB, CLOB) for {@link AbstractMySqlParameter} implementations.
  */
-abstract class AbstractLobParameter extends AbstractParameter {
+abstract class AbstractLobMySqlParameter extends AbstractMySqlParameter {
 
-    private static final Logger logger = Loggers.getLogger(AbstractLobParameter.class);
+    private static final Logger logger = Loggers.getLogger(AbstractLobMySqlParameter.class);
 
     @Override
     public final void dispose() {

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/AbstractMySqlParameter.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/AbstractMySqlParameter.java
@@ -16,12 +16,12 @@
 
 package io.asyncer.r2dbc.mysql.codec;
 
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 
 /**
- * Base class considers non null values for {@link Parameter} implementations.
+ * Base class considers non null values for {@link MySqlParameter} implementations.
  */
-abstract class AbstractParameter implements Parameter {
+abstract class AbstractMySqlParameter implements MySqlParameter {
 
     @Override
     public final String toString() {

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/BigDecimalCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/BigDecimalCodec.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
@@ -75,8 +75,8 @@ final class BigDecimalCodec extends AbstractClassedCodec<BigDecimal> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
-        return new BigDecimalParameter(allocator, (BigDecimal) value);
+    public MySqlParameter encode(Object value, CodecContext context) {
+        return new BigDecimalMySqlParameter(allocator, (BigDecimal) value);
     }
 
     @Override
@@ -126,13 +126,13 @@ final class BigDecimalCodec extends AbstractClassedCodec<BigDecimal> {
         return new BigDecimal(buf.toString(StandardCharsets.US_ASCII));
     }
 
-    private static final class BigDecimalParameter extends AbstractParameter {
+    private static final class BigDecimalMySqlParameter extends AbstractMySqlParameter {
 
         private final ByteBufAllocator allocator;
 
         private final BigDecimal value;
 
-        private BigDecimalParameter(ByteBufAllocator allocator, BigDecimal value) {
+        private BigDecimalMySqlParameter(ByteBufAllocator allocator, BigDecimal value) {
             this.allocator = allocator;
             this.value = value;
         }
@@ -157,11 +157,11 @@ final class BigDecimalCodec extends AbstractClassedCodec<BigDecimal> {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof BigDecimalParameter)) {
+            if (!(o instanceof BigDecimalMySqlParameter)) {
                 return false;
             }
 
-            BigDecimalParameter that = (BigDecimalParameter) o;
+            BigDecimalMySqlParameter that = (BigDecimalMySqlParameter) o;
 
             return value.equals(that.value);
         }

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/BigIntegerCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/BigIntegerCodec.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
@@ -80,14 +80,14 @@ final class BigIntegerCodec extends AbstractClassedCodec<BigInteger> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
+    public MySqlParameter encode(Object value, CodecContext context) {
         BigInteger i = (BigInteger) value;
 
         if (i.bitLength() < Long.SIZE) {
             return LongCodec.encodeLong(allocator, i.longValue());
         }
 
-        return new BigIntegerParameter(allocator, (BigInteger) value);
+        return new BigIntegerMySqlParameter(allocator, (BigInteger) value);
     }
 
     @Override
@@ -138,13 +138,13 @@ final class BigIntegerCodec extends AbstractClassedCodec<BigInteger> {
         return new BigDecimal(buf.toString(StandardCharsets.US_ASCII)).toBigInteger();
     }
 
-    private static class BigIntegerParameter extends AbstractParameter {
+    private static class BigIntegerMySqlParameter extends AbstractMySqlParameter {
 
         private final ByteBufAllocator allocator;
 
         private final BigInteger value;
 
-        private BigIntegerParameter(ByteBufAllocator allocator, BigInteger value) {
+        private BigIntegerMySqlParameter(ByteBufAllocator allocator, BigInteger value) {
             this.allocator = allocator;
             this.value = value;
         }
@@ -169,10 +169,10 @@ final class BigIntegerCodec extends AbstractClassedCodec<BigInteger> {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof BigIntegerParameter)) {
+            if (!(o instanceof BigIntegerMySqlParameter)) {
                 return false;
             }
-            BigIntegerParameter that = (BigIntegerParameter) o;
+            BigIntegerMySqlParameter that = (BigIntegerMySqlParameter) o;
             return value.equals(that.value);
         }
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/BitSetCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/BitSetCodec.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
@@ -55,7 +55,7 @@ final class BitSetCodec extends AbstractClassedCodec<BitSet> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
+    public MySqlParameter encode(Object value, CodecContext context) {
         BitSet set = (BitSet) value;
         long bits;
         if (set.isEmpty()) {
@@ -83,7 +83,7 @@ final class BitSetCodec extends AbstractClassedCodec<BitSet> {
             type = MySqlType.BIGINT;
         }
 
-        return new BitSetParameter(allocator, bits, type);
+        return new BitSetMySqlParameter(allocator, bits, type);
     }
 
     @Override
@@ -105,7 +105,7 @@ final class BitSetCodec extends AbstractClassedCodec<BitSet> {
         return bytes;
     }
 
-    private static final class BitSetParameter extends AbstractParameter {
+    private static final class BitSetMySqlParameter extends AbstractMySqlParameter {
 
         private final ByteBufAllocator allocator;
 
@@ -113,7 +113,7 @@ final class BitSetCodec extends AbstractClassedCodec<BitSet> {
 
         private final MySqlType type;
 
-        private BitSetParameter(ByteBufAllocator allocator, long value, MySqlType type) {
+        private BitSetMySqlParameter(ByteBufAllocator allocator, long value, MySqlType type) {
             this.allocator = allocator;
             this.value = value;
             this.type = type;
@@ -158,11 +158,11 @@ final class BitSetCodec extends AbstractClassedCodec<BitSet> {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof BitSetParameter)) {
+            if (!(o instanceof BitSetMySqlParameter)) {
                 return false;
             }
 
-            BitSetParameter that = (BitSetParameter) o;
+            BitSetMySqlParameter that = (BitSetMySqlParameter) o;
 
             return value == that.value;
         }

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/BlobCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/BlobCodec.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.codec.lob.LobUtils;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
@@ -75,8 +75,8 @@ final class BlobCodec implements MassiveCodec<Blob> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
-        return new BlobParameter(allocator, (Blob) value);
+    public MySqlParameter encode(Object value, CodecContext context) {
+        return new BlobMySqlParameter(allocator, (Blob) value);
     }
 
     static List<ByteBuf> toList(List<ByteBuf> buffers) {
@@ -105,13 +105,13 @@ final class BlobCodec implements MassiveCodec<Blob> {
         }
     }
 
-    private static final class BlobParameter extends AbstractLobParameter {
+    private static final class BlobMySqlParameter extends AbstractLobMySqlParameter {
 
         private final ByteBufAllocator allocator;
 
         private final AtomicReference<Blob> blob;
 
-        private BlobParameter(ByteBufAllocator allocator, Blob blob) {
+        private BlobMySqlParameter(ByteBufAllocator allocator, Blob blob) {
             this.allocator = allocator;
             this.blob = new AtomicReference<>(blob);
         }
@@ -197,11 +197,11 @@ final class BlobCodec implements MassiveCodec<Blob> {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof BlobParameter)) {
+            if (!(o instanceof BlobMySqlParameter)) {
                 return false;
             }
 
-            BlobParameter blobValue = (BlobParameter) o;
+            BlobMySqlParameter blobValue = (BlobMySqlParameter) o;
 
             return Objects.equals(this.blob.get(), blobValue.blob.get());
         }

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/BooleanCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/BooleanCodec.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
@@ -45,8 +45,8 @@ final class BooleanCodec extends AbstractPrimitiveCodec<Boolean> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
-        return new BooleanParameter(allocator, (Boolean) value);
+    public MySqlParameter encode(Object value, CodecContext context) {
+        return new BooleanMySqlParameter(allocator, (Boolean) value);
     }
 
     @Override
@@ -55,13 +55,13 @@ final class BooleanCodec extends AbstractPrimitiveCodec<Boolean> {
         return (type == MySqlType.BIT || type == MySqlType.TINYINT) && metadata.getNativePrecision() == 1;
     }
 
-    private static final class BooleanParameter extends AbstractParameter {
+    private static final class BooleanMySqlParameter extends AbstractMySqlParameter {
 
         private final ByteBufAllocator allocator;
 
         private final boolean value;
 
-        private BooleanParameter(ByteBufAllocator allocator, boolean value) {
+        private BooleanMySqlParameter(ByteBufAllocator allocator, boolean value) {
             this.allocator = allocator;
             this.value = value;
         }
@@ -88,11 +88,11 @@ final class BooleanCodec extends AbstractPrimitiveCodec<Boolean> {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof BooleanParameter)) {
+            if (!(o instanceof BooleanMySqlParameter)) {
                 return false;
             }
 
-            BooleanParameter that = (BooleanParameter) o;
+            BooleanMySqlParameter that = (BooleanMySqlParameter) o;
 
             return value == that.value;
         }

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/ByteArrayCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/ByteArrayCodec.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.asyncer.r2dbc.mysql.util.VarIntUtils;
@@ -55,8 +55,8 @@ final class ByteArrayCodec extends AbstractClassedCodec<byte[]> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
-        return new ByteArrayParameter(allocator, (byte[]) value);
+    public MySqlParameter encode(Object value, CodecContext context) {
+        return new ByteArrayMySqlParameter(allocator, (byte[]) value);
     }
 
     @Override
@@ -83,13 +83,13 @@ final class ByteArrayCodec extends AbstractClassedCodec<byte[]> {
         }
     }
 
-    private static final class ByteArrayParameter extends AbstractParameter {
+    private static final class ByteArrayMySqlParameter extends AbstractMySqlParameter {
 
         private final ByteBufAllocator allocator;
 
         private final byte[] value;
 
-        private ByteArrayParameter(ByteBufAllocator allocator, byte[] value) {
+        private ByteArrayMySqlParameter(ByteBufAllocator allocator, byte[] value) {
             this.allocator = allocator;
             this.value = value;
         }
@@ -114,11 +114,11 @@ final class ByteArrayCodec extends AbstractClassedCodec<byte[]> {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof ByteArrayParameter)) {
+            if (!(o instanceof ByteArrayMySqlParameter)) {
                 return false;
             }
 
-            ByteArrayParameter that = (ByteArrayParameter) o;
+            ByteArrayMySqlParameter that = (ByteArrayMySqlParameter) o;
 
             return Arrays.equals(value, that.value);
         }

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/ByteBufferCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/ByteBufferCodec.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.asyncer.r2dbc.mysql.util.VarIntUtils;
@@ -54,8 +54,8 @@ final class ByteBufferCodec extends AbstractClassedCodec<ByteBuffer> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
-        return new ByteBufferParameter(allocator, (ByteBuffer) value);
+    public MySqlParameter encode(Object value, CodecContext context) {
+        return new ByteBufferMySqlParameter(allocator, (ByteBuffer) value);
     }
 
     @Override
@@ -68,13 +68,13 @@ final class ByteBufferCodec extends AbstractClassedCodec<ByteBuffer> {
         return metadata.getType().isBinary();
     }
 
-    private static final class ByteBufferParameter extends AbstractParameter {
+    private static final class ByteBufferMySqlParameter extends AbstractMySqlParameter {
 
         private final ByteBufAllocator allocator;
 
         private final ByteBuffer buffer;
 
-        private ByteBufferParameter(ByteBufAllocator allocator, ByteBuffer buffer) {
+        private ByteBufferMySqlParameter(ByteBufAllocator allocator, ByteBuffer buffer) {
             this.allocator = allocator;
             this.buffer = buffer;
         }
@@ -115,10 +115,10 @@ final class ByteBufferCodec extends AbstractClassedCodec<ByteBuffer> {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof ByteBufferParameter)) {
+            if (!(o instanceof ByteBufferMySqlParameter)) {
                 return false;
             }
-            ByteBufferParameter that = (ByteBufferParameter) o;
+            ByteBufferMySqlParameter that = (ByteBufferMySqlParameter) o;
             return buffer.equals(that.buffer);
         }
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/ByteCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/ByteCodec.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
@@ -45,8 +45,8 @@ final class ByteCodec extends AbstractPrimitiveCodec<Byte> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
-        return new ByteParameter(allocator, (Byte) value);
+    public MySqlParameter encode(Object value, CodecContext context) {
+        return new ByteMySqlParameter(allocator, (Byte) value);
     }
 
     @Override
@@ -54,13 +54,13 @@ final class ByteCodec extends AbstractPrimitiveCodec<Byte> {
         return metadata.getType().isNumeric();
     }
 
-    static final class ByteParameter extends AbstractParameter {
+    static final class ByteMySqlParameter extends AbstractMySqlParameter {
 
         private final ByteBufAllocator allocator;
 
         private final byte value;
 
-        ByteParameter(ByteBufAllocator allocator, byte value) {
+        ByteMySqlParameter(ByteBufAllocator allocator, byte value) {
             this.allocator = allocator;
             this.value = value;
         }
@@ -85,11 +85,11 @@ final class ByteCodec extends AbstractPrimitiveCodec<Byte> {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof ByteParameter)) {
+            if (!(o instanceof ByteMySqlParameter)) {
                 return false;
             }
 
-            ByteParameter byteValue = (ByteParameter) o;
+            ByteMySqlParameter byteValue = (ByteMySqlParameter) o;
 
             return value == byteValue.value;
         }

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/ClobCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/ClobCodec.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.codec.lob.LobUtils;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
@@ -78,11 +78,11 @@ final class ClobCodec implements MassiveCodec<Clob> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
-        return new ClobParameter(allocator, (Clob) value, context);
+    public MySqlParameter encode(Object value, CodecContext context) {
+        return new ClobMySqlParameter(allocator, (Clob) value, context);
     }
 
-    private static class ClobParameter extends AbstractLobParameter {
+    private static class ClobMySqlParameter extends AbstractLobMySqlParameter {
 
         private final ByteBufAllocator allocator;
 
@@ -90,7 +90,7 @@ final class ClobCodec implements MassiveCodec<Clob> {
 
         private final CodecContext context;
 
-        private ClobParameter(ByteBufAllocator allocator, Clob clob, CodecContext context) {
+        private ClobMySqlParameter(ByteBufAllocator allocator, Clob clob, CodecContext context) {
             this.allocator = allocator;
             this.clob = new AtomicReference<>(clob);
             this.context = context;
@@ -177,11 +177,11 @@ final class ClobCodec implements MassiveCodec<Clob> {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof ClobParameter)) {
+            if (!(o instanceof ClobMySqlParameter)) {
                 return false;
             }
 
-            ClobParameter clobValue = (ClobParameter) o;
+            ClobMySqlParameter clobValue = (ClobMySqlParameter) o;
 
             return Objects.equals(this.clob.get(), clobValue.clob.get());
         }

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/Codec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/Codec.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.netty.buffer.ByteBuf;
 import reactor.util.annotation.Nullable;
 
@@ -62,11 +62,11 @@ public interface Codec<T> {
     boolean canEncode(Object value);
 
     /**
-     * Encode a value to a {@link Parameter}.
+     * Encode a value to a {@link MySqlParameter}.
      *
      * @param value   the specified value.
      * @param context the codec context.
-     * @return encoded {@link Parameter}.
+     * @return encoded {@link MySqlParameter}.
      */
-    Parameter encode(Object value, CodecContext context);
+    MySqlParameter encode(Object value, CodecContext context);
 }

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/Codecs.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/Codecs.java
@@ -18,7 +18,7 @@ package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
 import io.asyncer.r2dbc.mysql.message.FieldValue;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.netty.buffer.ByteBufAllocator;
 import reactor.util.annotation.Nullable;
 
@@ -74,21 +74,21 @@ public interface Codecs {
     <T> T decodeLastInsertId(long value, Class<?> type);
 
     /**
-     * Encode a value to a {@link Parameter}.
+     * Encode a value to a {@link MySqlParameter}.
      *
      * @param value   the value which should be decoded.
      * @param context the codec context.
-     * @return encoded {@link Parameter}.
+     * @return encoded {@link MySqlParameter}.
      * @throws IllegalArgumentException if any parameter is {@code null}, or {@code value} cannot be encoded.
      */
-    Parameter encode(Object value, CodecContext context);
+    MySqlParameter encode(Object value, CodecContext context);
 
     /**
-     * Encode a null {@link Parameter}.
+     * Encode a null {@link MySqlParameter}.
      *
-     * @return a {@link Parameter} take a {@code null} value.
+     * @return a {@link MySqlParameter} take a {@code null} value.
      */
-    Parameter encodeNull();
+    MySqlParameter encodeNull();
 
     /**
      * Create a builder from a {@link ByteBufAllocator}.

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/DefaultCodecs.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/DefaultCodecs.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.message.FieldValue;
 import io.asyncer.r2dbc.mysql.message.LargeFieldValue;
 import io.asyncer.r2dbc.mysql.message.NormalFieldValue;
@@ -165,7 +165,7 @@ final class DefaultCodecs implements Codecs {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
+    public MySqlParameter encode(Object value, CodecContext context) {
         requireNonNull(value, "value must not be null");
         requireNonNull(context, "context must not be null");
 
@@ -179,8 +179,8 @@ final class DefaultCodecs implements Codecs {
     }
 
     @Override
-    public Parameter encodeNull() {
-        return NullParameter.INSTANCE;
+    public MySqlParameter encodeNull() {
+        return NullMySqlParameter.INSTANCE;
     }
 
     @Nullable

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/DoubleCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/DoubleCodec.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
@@ -61,8 +61,8 @@ final class DoubleCodec extends AbstractPrimitiveCodec<Double> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
-        return new DoubleParameter(allocator, (Double) value);
+    public MySqlParameter encode(Object value, CodecContext context) {
+        return new DoubleMySqlParameter(allocator, (Double) value);
     }
 
     @Override
@@ -108,13 +108,13 @@ final class DoubleCodec extends AbstractPrimitiveCodec<Double> {
         throw new IllegalStateException("Cannot decode type " + type + " as a Double");
     }
 
-    private static final class DoubleParameter extends AbstractParameter {
+    private static final class DoubleMySqlParameter extends AbstractMySqlParameter {
 
         private final ByteBufAllocator allocator;
 
         private final double value;
 
-        private DoubleParameter(ByteBufAllocator allocator, double value) {
+        private DoubleMySqlParameter(ByteBufAllocator allocator, double value) {
             this.allocator = allocator;
             this.value = value;
         }
@@ -147,11 +147,11 @@ final class DoubleCodec extends AbstractPrimitiveCodec<Double> {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof DoubleParameter)) {
+            if (!(o instanceof DoubleMySqlParameter)) {
                 return false;
             }
 
-            DoubleParameter that = (DoubleParameter) o;
+            DoubleMySqlParameter that = (DoubleMySqlParameter) o;
 
             return Double.compare(that.value, value) == 0;
         }

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/DurationCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/DurationCodec.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
@@ -57,8 +57,8 @@ final class DurationCodec extends AbstractClassedCodec<Duration> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
-        return new DurationParameter(allocator, (Duration) value);
+    public MySqlParameter encode(Object value, CodecContext context) {
+        return new DurationMySqlParameter(allocator, (Duration) value);
     }
 
     @Override
@@ -158,13 +158,13 @@ final class DurationCodec extends AbstractClassedCodec<Duration> {
         return Duration.ofSeconds(isNegative ? -totalSeconds : totalSeconds, isNegative ? -nanos : nanos);
     }
 
-    private static final class DurationParameter extends AbstractParameter {
+    private static final class DurationMySqlParameter extends AbstractMySqlParameter {
 
         private final ByteBufAllocator allocator;
 
         private final Duration value;
 
-        private DurationParameter(ByteBufAllocator allocator, Duration value) {
+        private DurationMySqlParameter(ByteBufAllocator allocator, Duration value) {
             this.allocator = allocator;
             this.value = value;
         }
@@ -231,11 +231,11 @@ final class DurationCodec extends AbstractClassedCodec<Duration> {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof DurationParameter)) {
+            if (!(o instanceof DurationMySqlParameter)) {
                 return false;
             }
 
-            DurationParameter that = (DurationParameter) o;
+            DurationMySqlParameter that = (DurationMySqlParameter) o;
 
             return value.equals(that.value);
         }

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/EnumCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/EnumCodec.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
@@ -57,11 +57,11 @@ final class EnumCodec implements Codec<Enum<?>> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
-        return new EnumParameter(allocator, (Enum<?>) value, context);
+    public MySqlParameter encode(Object value, CodecContext context) {
+        return new EnumMySqlParameter(allocator, (Enum<?>) value, context);
     }
 
-    private static final class EnumParameter extends AbstractParameter {
+    private static final class EnumMySqlParameter extends AbstractMySqlParameter {
 
         private final ByteBufAllocator allocator;
 
@@ -69,7 +69,7 @@ final class EnumCodec implements Codec<Enum<?>> {
 
         private final CodecContext context;
 
-        private EnumParameter(ByteBufAllocator allocator, Enum<?> value, CodecContext context) {
+        private EnumMySqlParameter(ByteBufAllocator allocator, Enum<?> value, CodecContext context) {
             this.allocator = allocator;
             this.value = value;
             this.context = context;
@@ -95,11 +95,11 @@ final class EnumCodec implements Codec<Enum<?>> {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof EnumParameter)) {
+            if (!(o instanceof EnumMySqlParameter)) {
                 return false;
             }
 
-            EnumParameter enumValue = (EnumParameter) o;
+            EnumMySqlParameter enumValue = (EnumMySqlParameter) o;
 
             return value.equals(enumValue.value);
         }

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/FloatCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/FloatCodec.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
@@ -61,8 +61,8 @@ final class FloatCodec extends AbstractPrimitiveCodec<Float> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
-        return new FloatParameter(allocator, (Float) value);
+    public MySqlParameter encode(Object value, CodecContext context) {
+        return new FloatMySqlParameter(allocator, (Float) value);
     }
 
     @Override
@@ -108,13 +108,13 @@ final class FloatCodec extends AbstractPrimitiveCodec<Float> {
         throw new IllegalStateException("Cannot decode type " + type + " as a Float");
     }
 
-    private static final class FloatParameter extends AbstractParameter {
+    private static final class FloatMySqlParameter extends AbstractMySqlParameter {
 
         private final ByteBufAllocator allocator;
 
         private final float value;
 
-        private FloatParameter(ByteBufAllocator allocator, float value) {
+        private FloatMySqlParameter(ByteBufAllocator allocator, float value) {
             this.allocator = allocator;
             this.value = value;
         }
@@ -147,11 +147,11 @@ final class FloatCodec extends AbstractPrimitiveCodec<Float> {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof FloatParameter)) {
+            if (!(o instanceof FloatMySqlParameter)) {
                 return false;
             }
 
-            FloatParameter that = (FloatParameter) o;
+            FloatMySqlParameter that = (FloatMySqlParameter) o;
 
             return Float.compare(that.value, value) == 0;
         }

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/InstantCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/InstantCodec.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
@@ -51,8 +51,8 @@ final class InstantCodec implements Codec<Instant> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
-        return new InstantParameter(allocator, (Instant) value, context);
+    public MySqlParameter encode(Object value, CodecContext context) {
+        return new InstantMySqlParameter(allocator, (Instant) value, context);
     }
 
     @Override
@@ -65,7 +65,7 @@ final class InstantCodec implements Codec<Instant> {
         return DateTimes.canDecodeDateTime(metadata.getType(), target, Instant.class);
     }
 
-    private static final class InstantParameter extends AbstractParameter {
+    private static final class InstantMySqlParameter extends AbstractMySqlParameter {
 
         private final ByteBufAllocator allocator;
 
@@ -73,7 +73,7 @@ final class InstantCodec implements Codec<Instant> {
 
         private final CodecContext context;
 
-        private InstantParameter(ByteBufAllocator allocator, Instant value, CodecContext context) {
+        private InstantMySqlParameter(ByteBufAllocator allocator, Instant value, CodecContext context) {
             this.allocator = allocator;
             this.value = value;
             this.context = context;
@@ -102,7 +102,7 @@ final class InstantCodec implements Codec<Instant> {
             if (o == null || getClass() != o.getClass()) {
                 return false;
             }
-            InstantParameter that = (InstantParameter) o;
+            InstantMySqlParameter that = (InstantMySqlParameter) o;
             return value.equals(that.value);
         }
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/IntegerCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/IntegerCodec.java
@@ -17,8 +17,10 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
+import io.asyncer.r2dbc.mysql.codec.ByteCodec.ByteMySqlParameter;
+import io.asyncer.r2dbc.mysql.codec.ShortCodec.ShortMySqlParameter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -48,16 +50,16 @@ final class IntegerCodec extends AbstractPrimitiveCodec<Integer> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
+    public MySqlParameter encode(Object value, CodecContext context) {
         int v = (Integer) value;
 
         if ((byte) v == v) {
-            return new ByteCodec.ByteParameter(allocator, (byte) v);
+            return new ByteMySqlParameter(allocator, (byte) v);
         } else if ((short) v == v) {
-            return new ShortCodec.ShortParameter(allocator, (short) v);
+            return new ShortMySqlParameter(allocator, (short) v);
         }
 
-        return new IntParameter(allocator, v);
+        return new IntMySqlParameter(allocator, v);
     }
 
     @Override
@@ -117,13 +119,13 @@ final class IntegerCodec extends AbstractPrimitiveCodec<Integer> {
         return new BigDecimal(buf.toString(StandardCharsets.US_ASCII)).intValue();
     }
 
-    static final class IntParameter extends AbstractParameter {
+    static final class IntMySqlParameter extends AbstractMySqlParameter {
 
         private final ByteBufAllocator allocator;
 
         private final int value;
 
-        IntParameter(ByteBufAllocator allocator, int value) {
+        IntMySqlParameter(ByteBufAllocator allocator, int value) {
             this.allocator = allocator;
             this.value = value;
         }
@@ -148,11 +150,11 @@ final class IntegerCodec extends AbstractPrimitiveCodec<Integer> {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof IntParameter)) {
+            if (!(o instanceof IntMySqlParameter)) {
                 return false;
             }
 
-            IntParameter intValue = (IntParameter) o;
+            IntMySqlParameter intValue = (IntMySqlParameter) o;
 
             return value == intValue.value;
         }

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/LocalDateCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/LocalDateCodec.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
@@ -57,8 +57,8 @@ final class LocalDateCodec extends AbstractClassedCodec<LocalDate> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
-        return new LocalDateParameter(allocator, (LocalDate) value);
+    public MySqlParameter encode(Object value, CodecContext context) {
+        return new LocalDateMySqlParameter(allocator, (LocalDate) value);
     }
 
     @Override
@@ -156,13 +156,13 @@ final class LocalDateCodec extends AbstractClassedCodec<LocalDate> {
         writer.writeInt(day);
     }
 
-    private static final class LocalDateParameter extends AbstractParameter {
+    private static final class LocalDateMySqlParameter extends AbstractMySqlParameter {
 
         private final ByteBufAllocator allocator;
 
         private final LocalDate value;
 
-        private LocalDateParameter(ByteBufAllocator allocator, LocalDate value) {
+        private LocalDateMySqlParameter(ByteBufAllocator allocator, LocalDate value) {
             this.allocator = allocator;
             this.value = value;
         }
@@ -187,11 +187,11 @@ final class LocalDateCodec extends AbstractClassedCodec<LocalDate> {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof LocalDateParameter)) {
+            if (!(o instanceof LocalDateMySqlParameter)) {
                 return false;
             }
 
-            LocalDateParameter that = (LocalDateParameter) o;
+            LocalDateMySqlParameter that = (LocalDateMySqlParameter) o;
 
             return value.equals(that.value);
         }

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/LocalDateTimeCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/LocalDateTimeCodec.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
@@ -59,8 +59,8 @@ final class LocalDateTimeCodec implements ParametrizedCodec<LocalDateTime> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
-        return new LocalDateTimeParameter(allocator, (LocalDateTime) value);
+    public MySqlParameter encode(Object value, CodecContext context) {
+        return new LocalDateTimeMySqlParameter(allocator, (LocalDateTime) value);
     }
 
     @Override
@@ -158,13 +158,13 @@ final class LocalDateTimeCodec implements ParametrizedCodec<LocalDateTime> {
         return LocalDateTime.of(date, LocalTime.of(hour, minute, second, nano));
     }
 
-    private static final class LocalDateTimeParameter extends AbstractParameter {
+    private static final class LocalDateTimeMySqlParameter extends AbstractMySqlParameter {
 
         private final ByteBufAllocator allocator;
 
         private final LocalDateTime value;
 
-        private LocalDateTimeParameter(ByteBufAllocator allocator, LocalDateTime value) {
+        private LocalDateTimeMySqlParameter(ByteBufAllocator allocator, LocalDateTime value) {
             this.allocator = allocator;
             this.value = value;
         }
@@ -189,11 +189,11 @@ final class LocalDateTimeCodec implements ParametrizedCodec<LocalDateTime> {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof LocalDateTimeParameter)) {
+            if (!(o instanceof LocalDateTimeMySqlParameter)) {
                 return false;
             }
 
-            LocalDateTimeParameter that = (LocalDateTimeParameter) o;
+            LocalDateTimeMySqlParameter that = (LocalDateTimeMySqlParameter) o;
 
             return value.equals(that.value);
         }

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/LocalTimeCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/LocalTimeCodec.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
@@ -64,8 +64,8 @@ final class LocalTimeCodec extends AbstractClassedCodec<LocalTime> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
-        return new LocalTimeParameter(allocator, (LocalTime) value);
+    public MySqlParameter encode(Object value, CodecContext context) {
+        return new LocalTimeMySqlParameter(allocator, (LocalTime) value);
     }
 
     @Override
@@ -193,13 +193,13 @@ final class LocalTimeCodec extends AbstractClassedCodec<LocalTime> {
         return LocalTime.ofNanoOfDay(((total % NANOS_OF_DAY) + NANOS_OF_DAY) % NANOS_OF_DAY);
     }
 
-    private static final class LocalTimeParameter extends AbstractParameter {
+    private static final class LocalTimeMySqlParameter extends AbstractMySqlParameter {
 
         private final ByteBufAllocator allocator;
 
         private final LocalTime value;
 
-        private LocalTimeParameter(ByteBufAllocator allocator, LocalTime value) {
+        private LocalTimeMySqlParameter(ByteBufAllocator allocator, LocalTime value) {
             this.allocator = allocator;
             this.value = value;
         }
@@ -224,11 +224,11 @@ final class LocalTimeCodec extends AbstractClassedCodec<LocalTime> {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof LocalTimeParameter)) {
+            if (!(o instanceof LocalTimeMySqlParameter)) {
                 return false;
             }
 
-            LocalTimeParameter that = (LocalTimeParameter) o;
+            LocalTimeMySqlParameter that = (LocalTimeMySqlParameter) o;
 
             return value.equals(that.value);
         }

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/LongCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/LongCodec.java
@@ -17,8 +17,11 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
+import io.asyncer.r2dbc.mysql.codec.ByteCodec.ByteMySqlParameter;
+import io.asyncer.r2dbc.mysql.codec.IntegerCodec.IntMySqlParameter;
+import io.asyncer.r2dbc.mysql.codec.ShortCodec.ShortMySqlParameter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -63,7 +66,7 @@ final class LongCodec extends AbstractPrimitiveCodec<Long> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
+    public MySqlParameter encode(Object value, CodecContext context) {
         return encodeLong(allocator, (Long) value);
     }
 
@@ -72,16 +75,16 @@ final class LongCodec extends AbstractPrimitiveCodec<Long> {
         return metadata.getType().isNumeric();
     }
 
-    static Parameter encodeLong(ByteBufAllocator allocator, long v) {
+    static MySqlParameter encodeLong(ByteBufAllocator allocator, long v) {
         if ((byte) v == v) {
-            return new ByteCodec.ByteParameter(allocator, (byte) v);
+            return new ByteMySqlParameter(allocator, (byte) v);
         } else if ((short) v == v) {
-            return new ShortCodec.ShortParameter(allocator, (short) v);
+            return new ShortMySqlParameter(allocator, (short) v);
         } else if ((int) v == v) {
-            return new IntegerCodec.IntParameter(allocator, (int) v);
+            return new IntMySqlParameter(allocator, (int) v);
         }
 
-        return new LongParameter(allocator, v);
+        return new LongMySqlParameter(allocator, v);
     }
 
     private static long decodeBinary(ByteBuf buf, MySqlType type) {
@@ -120,13 +123,13 @@ final class LongCodec extends AbstractPrimitiveCodec<Long> {
         return new BigDecimal(buf.toString(StandardCharsets.US_ASCII)).longValue();
     }
 
-    private static final class LongParameter extends AbstractParameter {
+    private static final class LongMySqlParameter extends AbstractMySqlParameter {
 
         private final ByteBufAllocator allocator;
 
         private final long value;
 
-        private LongParameter(ByteBufAllocator allocator, long value) {
+        private LongMySqlParameter(ByteBufAllocator allocator, long value) {
             this.allocator = allocator;
             this.value = value;
         }
@@ -151,11 +154,11 @@ final class LongCodec extends AbstractPrimitiveCodec<Long> {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof LongParameter)) {
+            if (!(o instanceof LongMySqlParameter)) {
                 return false;
             }
 
-            LongParameter longValue = (LongParameter) o;
+            LongMySqlParameter longValue = (LongMySqlParameter) o;
 
             return value == longValue.value;
         }

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/NullMySqlParameter.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/NullMySqlParameter.java
@@ -16,21 +16,21 @@
 
 package io.asyncer.r2dbc.mysql.codec;
 
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
 import reactor.core.publisher.Mono;
 
 /**
- * An implementation of {@link Parameter} which considers value is {@code null}.
+ * An implementation of {@link MySqlParameter} which considers value is {@code null}.
  * <p>
  * Note: the parameter is marked with a bitmap of {@code null}, so {@link #publishBinary} will not do
  * anything.
  */
-final class NullParameter implements Parameter {
+final class NullMySqlParameter implements MySqlParameter {
 
-    static final NullParameter INSTANCE = new NullParameter();
+    static final NullMySqlParameter INSTANCE = new NullMySqlParameter();
 
     @Override
     public boolean isNull() {
@@ -68,5 +68,5 @@ final class NullParameter implements Parameter {
         return "Parameter{REDACTED}";
     }
 
-    private NullParameter() { }
+    private NullMySqlParameter() { }
 }

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/OffsetDateTimeCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/OffsetDateTimeCodec.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
@@ -56,8 +56,8 @@ final class OffsetDateTimeCodec implements Codec<OffsetDateTime> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
-        return new OffsetDateTimeParameter(allocator, (OffsetDateTime) value, context);
+    public MySqlParameter encode(Object value, CodecContext context) {
+        return new OffsetDateTimeMySqlParameter(allocator, (OffsetDateTime) value, context);
     }
 
     @Override
@@ -70,7 +70,7 @@ final class OffsetDateTimeCodec implements Codec<OffsetDateTime> {
         return DateTimes.canDecodeDateTime(metadata.getType(), target, OffsetDateTime.class);
     }
 
-    private static final class OffsetDateTimeParameter extends AbstractParameter {
+    private static final class OffsetDateTimeMySqlParameter extends AbstractMySqlParameter {
 
         private final ByteBufAllocator allocator;
 
@@ -78,8 +78,8 @@ final class OffsetDateTimeCodec implements Codec<OffsetDateTime> {
 
         private final CodecContext context;
 
-        private OffsetDateTimeParameter(ByteBufAllocator allocator, OffsetDateTime value,
-            CodecContext context) {
+        private OffsetDateTimeMySqlParameter(ByteBufAllocator allocator, OffsetDateTime value,
+                                             CodecContext context) {
             this.allocator = allocator;
             this.value = value;
             this.context = context;
@@ -108,7 +108,7 @@ final class OffsetDateTimeCodec implements Codec<OffsetDateTime> {
             if (o == null || getClass() != o.getClass()) {
                 return false;
             }
-            OffsetDateTimeParameter that = (OffsetDateTimeParameter) o;
+            OffsetDateTimeMySqlParameter that = (OffsetDateTimeMySqlParameter) o;
             return value.equals(that.value);
         }
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/OffsetTimeCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/OffsetTimeCodec.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
@@ -50,8 +50,8 @@ final class OffsetTimeCodec extends AbstractClassedCodec<OffsetTime> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
-        return new OffsetTimeParameter(allocator, (OffsetTime) value, context);
+    public MySqlParameter encode(Object value, CodecContext context) {
+        return new OffsetTimeMySqlParameter(allocator, (OffsetTime) value, context);
     }
 
     @Override
@@ -64,7 +64,7 @@ final class OffsetTimeCodec extends AbstractClassedCodec<OffsetTime> {
         return metadata.getType() == MySqlType.TIME;
     }
 
-    private static final class OffsetTimeParameter extends AbstractParameter {
+    private static final class OffsetTimeMySqlParameter extends AbstractMySqlParameter {
 
         private final ByteBufAllocator allocator;
 
@@ -72,7 +72,7 @@ final class OffsetTimeCodec extends AbstractClassedCodec<OffsetTime> {
 
         private final CodecContext context;
 
-        private OffsetTimeParameter(ByteBufAllocator allocator, OffsetTime value, CodecContext context) {
+        private OffsetTimeMySqlParameter(ByteBufAllocator allocator, OffsetTime value, CodecContext context) {
             this.allocator = allocator;
             this.value = value;
             this.context = context;
@@ -98,11 +98,11 @@ final class OffsetTimeCodec extends AbstractClassedCodec<OffsetTime> {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof OffsetTimeParameter)) {
+            if (!(o instanceof OffsetTimeMySqlParameter)) {
                 return false;
             }
 
-            OffsetTimeParameter that = (OffsetTimeParameter) o;
+            OffsetTimeMySqlParameter that = (OffsetTimeMySqlParameter) o;
 
             return value.equals(that.value);
         }

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/SetCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/SetCodec.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.asyncer.r2dbc.mysql.util.InternalArrays;
@@ -127,13 +127,13 @@ final class SetCodec implements ParametrizedCodec<String[]> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
+    public MySqlParameter encode(Object value, CodecContext context) {
         if (value instanceof CharSequence[]) {
-            return new StringArrayParameter(allocator, InternalArrays.toImmutableList((CharSequence[]) value),
-                context);
+            return new StringArrayMySqlParameter(allocator, InternalArrays.toImmutableList((CharSequence[]) value),
+                                                 context);
         }
 
-        return new SetParameter(allocator, (Set<?>) value, context);
+        return new SetMySqlParameter(allocator, (Set<?>) value, context);
     }
 
     private static Set<?> buildSet(Class<?> subClass, boolean isEnum) {
@@ -289,7 +289,7 @@ final class SetCodec implements ParametrizedCodec<String[]> {
         }
     }
 
-    private static final class SetParameter extends AbstractParameter {
+    private static final class SetMySqlParameter extends AbstractMySqlParameter {
 
         private final ByteBufAllocator allocator;
 
@@ -297,7 +297,7 @@ final class SetCodec implements ParametrizedCodec<String[]> {
 
         private final CodecContext context;
 
-        private SetParameter(ByteBufAllocator allocator, Set<?> value, CodecContext context) {
+        private SetMySqlParameter(ByteBufAllocator allocator, Set<?> value, CodecContext context) {
             this.allocator = allocator;
             this.value = value;
             this.context = context;
@@ -330,11 +330,11 @@ final class SetCodec implements ParametrizedCodec<String[]> {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof SetParameter)) {
+            if (!(o instanceof SetMySqlParameter)) {
                 return false;
             }
 
-            SetParameter setValue = (SetParameter) o;
+            SetMySqlParameter setValue = (SetMySqlParameter) o;
 
             return value.equals(setValue.value);
         }
@@ -345,7 +345,7 @@ final class SetCodec implements ParametrizedCodec<String[]> {
         }
     }
 
-    private static final class StringArrayParameter extends AbstractParameter {
+    private static final class StringArrayMySqlParameter extends AbstractMySqlParameter {
 
         private final ByteBufAllocator allocator;
 
@@ -353,8 +353,8 @@ final class SetCodec implements ParametrizedCodec<String[]> {
 
         private final CodecContext context;
 
-        private StringArrayParameter(ByteBufAllocator allocator, List<CharSequence> value,
-            CodecContext context) {
+        private StringArrayMySqlParameter(ByteBufAllocator allocator, List<CharSequence> value,
+                                          CodecContext context) {
             this.allocator = allocator;
             this.value = value;
             this.context = context;
@@ -387,11 +387,11 @@ final class SetCodec implements ParametrizedCodec<String[]> {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof StringArrayParameter)) {
+            if (!(o instanceof StringArrayMySqlParameter)) {
                 return false;
             }
 
-            StringArrayParameter that = (StringArrayParameter) o;
+            StringArrayMySqlParameter that = (StringArrayMySqlParameter) o;
 
             return this.value.equals(that.value);
         }

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/ShortCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/ShortCodec.java
@@ -17,8 +17,9 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
+import io.asyncer.r2dbc.mysql.codec.ByteCodec.ByteMySqlParameter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -45,14 +46,14 @@ final class ShortCodec extends AbstractPrimitiveCodec<Short> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
+    public MySqlParameter encode(Object value, CodecContext context) {
         short v = (Short) value;
 
         if ((byte) v == v) {
-            return new ByteCodec.ByteParameter(allocator, (byte) v);
+            return new ByteMySqlParameter(allocator, (byte) v);
         }
 
-        return new ShortParameter(allocator, v);
+        return new ShortMySqlParameter(allocator, v);
     }
 
     @Override
@@ -60,13 +61,13 @@ final class ShortCodec extends AbstractPrimitiveCodec<Short> {
         return metadata.getType().isNumeric();
     }
 
-    static final class ShortParameter extends AbstractParameter {
+    static final class ShortMySqlParameter extends AbstractMySqlParameter {
 
         private final ByteBufAllocator allocator;
 
         private final short value;
 
-        ShortParameter(ByteBufAllocator allocator, short value) {
+        ShortMySqlParameter(ByteBufAllocator allocator, short value) {
             this.allocator = allocator;
             this.value = value;
         }
@@ -91,11 +92,11 @@ final class ShortCodec extends AbstractPrimitiveCodec<Short> {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof ShortParameter)) {
+            if (!(o instanceof ShortMySqlParameter)) {
                 return false;
             }
 
-            ShortParameter that = (ShortParameter) o;
+            ShortMySqlParameter that = (ShortMySqlParameter) o;
 
             return value == that.value;
         }

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/StringCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/StringCodec.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.asyncer.r2dbc.mysql.util.VarIntUtils;
@@ -52,8 +52,8 @@ final class StringCodec extends AbstractClassedCodec<String> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
-        return new StringParameter(allocator, (CharSequence) value, context);
+    public MySqlParameter encode(Object value, CodecContext context) {
+        return new StringMySqlParameter(allocator, (CharSequence) value, context);
     }
 
     @Override
@@ -82,7 +82,7 @@ final class StringCodec extends AbstractClassedCodec<String> {
         }
     }
 
-    private static class StringParameter extends AbstractParameter {
+    private static class StringMySqlParameter extends AbstractMySqlParameter {
 
         private final ByteBufAllocator allocator;
 
@@ -90,7 +90,7 @@ final class StringCodec extends AbstractClassedCodec<String> {
 
         private final CodecContext context;
 
-        private StringParameter(ByteBufAllocator allocator, CharSequence value, CodecContext context) {
+        private StringMySqlParameter(ByteBufAllocator allocator, CharSequence value, CodecContext context) {
             this.allocator = allocator;
             this.value = value;
             this.context = context;
@@ -116,11 +116,11 @@ final class StringCodec extends AbstractClassedCodec<String> {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof StringParameter)) {
+            if (!(o instanceof StringMySqlParameter)) {
                 return false;
             }
 
-            StringParameter that = (StringParameter) o;
+            StringMySqlParameter that = (StringMySqlParameter) o;
 
             return value.equals(that.value);
         }

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/YearCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/YearCodec.java
@@ -17,7 +17,10 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
+import io.asyncer.r2dbc.mysql.codec.ByteCodec.ByteMySqlParameter;
+import io.asyncer.r2dbc.mysql.codec.IntegerCodec.IntMySqlParameter;
+import io.asyncer.r2dbc.mysql.codec.ShortCodec.ShortMySqlParameter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -47,17 +50,17 @@ final class YearCodec extends AbstractClassedCodec<Year> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
+    public MySqlParameter encode(Object value, CodecContext context) {
         int year = ((Year) value).getValue();
 
         if ((byte) year == year) {
-            return new ByteCodec.ByteParameter(allocator, (byte) year);
+            return new ByteMySqlParameter(allocator, (byte) year);
         } else if ((short) year == year) {
-            return new ShortCodec.ShortParameter(allocator, (short) year);
+            return new ShortMySqlParameter(allocator, (short) year);
         }
 
         // Server does not support it, but still encodes it.
-        return new IntegerCodec.IntParameter(allocator, year);
+        return new IntMySqlParameter(allocator, year);
     }
 
     @Override

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/ZonedDateTimeCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/ZonedDateTimeCodec.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
@@ -57,8 +57,8 @@ final class ZonedDateTimeCodec implements ParametrizedCodec<ZonedDateTime> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
-        return new ZonedDateTimeParameter(allocator, (ZonedDateTime) value, context);
+    public MySqlParameter encode(Object value, CodecContext context) {
+        return new ZonedDateTimeMySqlParameter(allocator, (ZonedDateTime) value, context);
     }
 
     @Override
@@ -82,7 +82,7 @@ final class ZonedDateTimeCodec implements ParametrizedCodec<ZonedDateTime> {
         return origin == null ? null : ZonedDateTime.of(origin, context.getServerZoneId());
     }
 
-    private static final class ZonedDateTimeParameter extends AbstractParameter {
+    private static final class ZonedDateTimeMySqlParameter extends AbstractMySqlParameter {
 
         private final ByteBufAllocator allocator;
 
@@ -90,8 +90,8 @@ final class ZonedDateTimeCodec implements ParametrizedCodec<ZonedDateTime> {
 
         private final CodecContext context;
 
-        private ZonedDateTimeParameter(ByteBufAllocator allocator, ZonedDateTime value,
-            CodecContext context) {
+        private ZonedDateTimeMySqlParameter(ByteBufAllocator allocator, ZonedDateTime value,
+                                            CodecContext context) {
             this.allocator = allocator;
             this.value = value;
             this.context = context;
@@ -117,11 +117,11 @@ final class ZonedDateTimeCodec implements ParametrizedCodec<ZonedDateTime> {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof ZonedDateTimeParameter)) {
+            if (!(o instanceof ZonedDateTimeMySqlParameter)) {
                 return false;
             }
 
-            ZonedDateTimeParameter that = (ZonedDateTimeParameter) o;
+            ZonedDateTimeMySqlParameter that = (ZonedDateTimeMySqlParameter) o;
 
             return value.equals(that.value);
         }

--- a/src/main/java/io/asyncer/r2dbc/mysql/message/client/ParamWriter.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/message/client/ParamWriter.java
@@ -16,7 +16,7 @@
 
 package io.asyncer.r2dbc.mysql.message.client;
 
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.Query;
 import io.asyncer.r2dbc.mysql.util.OperatorUtils;
@@ -41,7 +41,7 @@ final class ParamWriter extends ParameterWriter {
     private static final char[] HEX_CHAR = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c',
         'd', 'e', 'f' };
 
-    private static final Consumer<Parameter> DISPOSE = Parameter::dispose;
+    private static final Consumer<MySqlParameter> DISPOSE = MySqlParameter::dispose;
 
     private final StringBuilder builder;
 
@@ -350,12 +350,12 @@ final class ParamWriter extends ParameterWriter {
         }
     }
 
-    static Mono<String> publish(Query query, Flux<Parameter> values) {
+    static Mono<String> publish(Query query, Flux<MySqlParameter> values) {
         return Mono.defer(() -> {
             ParamWriter writer = new ParamWriter(query);
 
             return OperatorUtils.discardOnCancel(values)
-                .doOnDiscard(Parameter.class, DISPOSE)
+                .doOnDiscard(MySqlParameter.class, DISPOSE)
                 .concatMap(it -> it.publishText(writer).doOnSuccess(writer::flushParameter))
                 .then(Mono.fromCallable(writer::toSql));
         });

--- a/src/main/java/io/asyncer/r2dbc/mysql/message/client/PreparedExecuteMessage.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/message/client/PreparedExecuteMessage.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.message.client;
 
 import io.asyncer.r2dbc.mysql.ConnectionContext;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.util.OperatorUtils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -59,7 +59,7 @@ public final class PreparedExecuteMessage implements ClientMessage, Disposable {
 
     private static final byte EXECUTE_FLAG = 0x17;
 
-    private static final Consumer<Parameter> DISPOSE = Parameter::dispose;
+    private static final Consumer<MySqlParameter> DISPOSE = MySqlParameter::dispose;
 
     private final int statementId;
 
@@ -68,9 +68,9 @@ public final class PreparedExecuteMessage implements ClientMessage, Disposable {
      */
     private final boolean immediate;
 
-    private final Parameter[] values;
+    private final MySqlParameter[] values;
 
-    public PreparedExecuteMessage(int statementId, boolean immediate, Parameter[] values) {
+    public PreparedExecuteMessage(int statementId, boolean immediate, MySqlParameter[] values) {
         this.values = requireNonNull(values, "values must not be null");
         this.statementId = statementId;
         this.immediate = immediate;
@@ -78,7 +78,7 @@ public final class PreparedExecuteMessage implements ClientMessage, Disposable {
 
     @Override
     public void dispose() {
-        for (Parameter value : values) {
+        for (MySqlParameter value : values) {
             value.dispose();
         }
         Arrays.fill(values, null);
@@ -115,7 +115,7 @@ public final class PreparedExecuteMessage implements ClientMessage, Disposable {
                     return Flux.just(buf);
                 }
 
-                List<Parameter> nonNull = new ArrayList<>(size);
+                List<MySqlParameter> nonNull = new ArrayList<>(size);
                 byte[] nullMap = fillNullBitmap(size, nonNull);
 
                 // Fill null-bitmap.
@@ -131,8 +131,8 @@ public final class PreparedExecuteMessage implements ClientMessage, Disposable {
                 writeTypes(buf, size);
 
                 Flux<ByteBuf> parameters = OperatorUtils.discardOnCancel(Flux.fromArray(values))
-                    .doOnDiscard(Parameter.class, DISPOSE)
-                    .concatMap(Parameter::publishBinary);
+                    .doOnDiscard(MySqlParameter.class, DISPOSE)
+                    .concatMap(MySqlParameter::publishBinary);
 
                 return Flux.just(buf).concatWith(parameters);
             } catch (Throwable e) {
@@ -143,11 +143,11 @@ public final class PreparedExecuteMessage implements ClientMessage, Disposable {
         });
     }
 
-    private byte[] fillNullBitmap(int size, List<Parameter> nonNull) {
+    private byte[] fillNullBitmap(int size, List<MySqlParameter> nonNull) {
         byte[] nullMap = new byte[ceilDiv8(size)];
 
         for (int i = 0; i < size; ++i) {
-            Parameter value = values[i];
+            MySqlParameter value = values[i];
 
             if (value.isNull()) {
                 nullMap[i >> 3] |= 1 << (i & 7);
@@ -166,7 +166,7 @@ public final class PreparedExecuteMessage implements ClientMessage, Disposable {
     }
 
     private void cancelParameters() {
-        for (Parameter value : values) {
+        for (MySqlParameter value : values) {
             value.dispose();
         }
     }

--- a/src/main/java/io/asyncer/r2dbc/mysql/message/client/PreparedTextQueryMessage.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/message/client/PreparedTextQueryMessage.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.message.client;
 
 import io.asyncer.r2dbc.mysql.ConnectionContext;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.Query;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -33,7 +33,7 @@ import static io.asyncer.r2dbc.mysql.util.AssertUtils.requireNonNull;
 /**
  * A client prepared query message based on text protocol.
  */
-public final class PreparedTextQueryMessage extends AtomicReference<Parameter[]>
+public final class PreparedTextQueryMessage extends AtomicReference<MySqlParameter[]>
     implements ClientMessage, Disposable {
 
     private final Query query;
@@ -45,7 +45,7 @@ public final class PreparedTextQueryMessage extends AtomicReference<Parameter[]>
      * @param values the parameter values.
      * @throws IllegalArgumentException if {@code query} or {@code values} is {@code null}.
      */
-    public PreparedTextQueryMessage(Query query, Parameter[] values) {
+    public PreparedTextQueryMessage(Query query, MySqlParameter[] values) {
         super(requireNonNull(values, "values must not be null"));
 
         this.query = requireNonNull(query, "query must not be null");
@@ -53,9 +53,9 @@ public final class PreparedTextQueryMessage extends AtomicReference<Parameter[]>
 
     @Override
     public void dispose() {
-        Parameter[] values = getAndSet(null);
+        MySqlParameter[] values = getAndSet(null);
 
-        for (Parameter value : values) {
+        for (MySqlParameter value : values) {
             if (value != null) {
                 value.dispose();
             }
@@ -73,8 +73,8 @@ public final class PreparedTextQueryMessage extends AtomicReference<Parameter[]>
         requireNonNull(context, "context must not be null");
 
         Charset charset = context.getClientCollation().getCharset();
-        Flux<Parameter> parameters = Flux.defer(() -> {
-            Parameter[] values = getAndSet(null);
+        Flux<MySqlParameter> parameters = Flux.defer(() -> {
+            MySqlParameter[] values = getAndSet(null);
 
             if (values == null) {
                 return Flux.error(new IllegalStateException("Parameters have been disposed"));

--- a/src/test/java/io/asyncer/r2dbc/mysql/QueryTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/QueryTest.java
@@ -145,13 +145,13 @@ class QueryTest {
 
         assertThat(binding.findUnbind()).isZero();
 
-        binding.add(0, MockParameter.INSTANCE);
+        binding.add(0, MockMySqlParameter.INSTANCE);
         assertThat(binding.findUnbind()).isOne();
 
-        query.getNamedIndexes().get("name").bind(binding, MockParameter.INSTANCE);
+        query.getNamedIndexes().get("name").bind(binding, MockMySqlParameter.INSTANCE);
         assertThat(binding.findUnbind()).isEqualTo(2);
 
-        query.getNamedIndexes().get("age").bind(binding, MockParameter.INSTANCE);
+        query.getNamedIndexes().get("age").bind(binding, MockMySqlParameter.INSTANCE);
         assertThat(binding.findUnbind()).isEqualTo(-1);
 
         query = Query.parse("INSERT INTO `user` (`id`, `nickname`, `real_name`) VALUE " +
@@ -162,13 +162,13 @@ class QueryTest {
 
         assertThat(binding.findUnbind()).isZero();
 
-        binding.add(0, MockParameter.INSTANCE);
+        binding.add(0, MockMySqlParameter.INSTANCE);
         assertThat(binding.findUnbind()).isOne();
 
-        query.getNamedIndexes().get("initName").bind(binding, MockParameter.INSTANCE);
+        query.getNamedIndexes().get("initName").bind(binding, MockMySqlParameter.INSTANCE);
         assertThat(binding.findUnbind()).isEqualTo(3);
 
-        query.getNamedIndexes().get("updateName").bind(binding, MockParameter.INSTANCE);
+        query.getNamedIndexes().get("updateName").bind(binding, MockMySqlParameter.INSTANCE);
         assertThat(binding.findUnbind()).isEqualTo(-1);
     }
 
@@ -323,9 +323,9 @@ class QueryTest {
         return result;
     }
 
-    private static final class MockParameter implements Parameter {
+    private static final class MockMySqlParameter implements MySqlParameter {
 
-        static final MockParameter INSTANCE = new MockParameter();
+        static final MockMySqlParameter INSTANCE = new MockMySqlParameter();
 
         @Override
         public boolean isNull() {
@@ -357,6 +357,6 @@ class QueryTest {
             return "MockParameter{}";
         }
 
-        private MockParameter() { }
+        private MockMySqlParameter() { }
     }
 }

--- a/src/test/java/io/asyncer/r2dbc/mysql/codec/CodecTestSupport.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/codec/CodecTestSupport.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.ConnectionContextTest;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.Query;
 import io.asyncer.r2dbc.mysql.collation.CharCollation;
@@ -68,7 +68,7 @@ interface CodecTestSupport<T> {
             AtomicReference<ByteBuf> buf = new AtomicReference<>();
             ByteBuf sized = sized(binaries[i]);
             try {
-                Parameter parameter = codec.encode(origin[i], context());
+                MySqlParameter parameter = codec.encode(origin[i], context());
                 merge(Flux.from(parameter.publishBinary()))
                     .doOnNext(buf::set)
                     .as(StepVerifier::create)

--- a/src/test/java/io/asyncer/r2dbc/mysql/json/JacksonCodec.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/json/JacksonCodec.java
@@ -18,7 +18,7 @@ package io.asyncer.r2dbc.mysql.json;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.codec.CodecContext;
 import io.asyncer.r2dbc.mysql.codec.ParametrizedCodec;
@@ -79,8 +79,8 @@ public final class JacksonCodec implements ParametrizedCodec<Object> {
     }
 
     @Override
-    public Parameter encode(Object value, CodecContext context) {
-        return new JacksonParameter(allocator, value, context);
+    public MySqlParameter encode(Object value, CodecContext context) {
+        return new JacksonMySqlParameter(allocator, value, context);
     }
 
     @Override
@@ -102,7 +102,7 @@ public final class JacksonCodec implements ParametrizedCodec<Object> {
         return mode.isDecode() && metadata.getType() == MySqlType.JSON;
     }
 
-    private static final class JacksonParameter implements Parameter {
+    private static final class JacksonMySqlParameter implements MySqlParameter {
 
         private final ByteBufAllocator allocator;
 
@@ -110,7 +110,7 @@ public final class JacksonCodec implements ParametrizedCodec<Object> {
 
         private final CodecContext context;
 
-        private JacksonParameter(ByteBufAllocator allocator, Object value, CodecContext context) {
+        private JacksonMySqlParameter(ByteBufAllocator allocator, Object value, CodecContext context) {
             this.allocator = allocator;
             this.value = value;
             this.context = context;

--- a/src/test/java/io/asyncer/r2dbc/mysql/message/client/MockMySqlParameter.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/message/client/MockMySqlParameter.java
@@ -16,7 +16,7 @@
 
 package io.asyncer.r2dbc.mysql.message.client;
 
-import io.asyncer.r2dbc.mysql.Parameter;
+import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
@@ -28,11 +28,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Mocked parameter for memory-leak unit tests.
  */
-final class MockParameter extends AtomicInteger implements Parameter {
+final class MockMySqlParameter extends AtomicInteger implements MySqlParameter {
 
     private final boolean success;
 
-    MockParameter(boolean success) {
+    MockMySqlParameter(boolean success) {
         super(1);
         this.success = success;
     }

--- a/src/test/java/io/asyncer/r2dbc/mysql/message/client/ParamWriterTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/message/client/ParamWriterTest.java
@@ -126,10 +126,10 @@ class ParamWriterTest {
 
     @Test
     void publishSuccess() {
-        MockParameter[] values = new MockParameter[SIZE];
+        MockMySqlParameter[] values = new MockMySqlParameter[SIZE];
 
         for (int i = 0; i < SIZE; ++i) {
-            values[i] = new MockParameter(true);
+            values[i] = new MockMySqlParameter(true);
         }
 
         Flux.from(ParamWriter.publish(parameterOnly(SIZE), Flux.fromArray(values)))
@@ -137,43 +137,43 @@ class ParamWriterTest {
             .expectNext(new String(new char[SIZE]).replace("\0", "''"))
             .verifyComplete();
 
-        assertThat(values).extracting(MockParameter::refCnt).containsOnly(0);
+        assertThat(values).extracting(MockMySqlParameter::refCnt).containsOnly(0);
     }
 
     @Test
     void publishPartially() {
-        MockParameter[] values = new MockParameter[SIZE];
+        MockMySqlParameter[] values = new MockMySqlParameter[SIZE];
 
         int i = 0;
 
         for (; i < SIZE >>> 1; ++i) {
-            values[i] = new MockParameter(true);
+            values[i] = new MockMySqlParameter(true);
         }
 
         for (; i < SIZE; ++i) {
-            values[i] = new MockParameter(false);
+            values[i] = new MockMySqlParameter(false);
         }
 
         Flux.from(ParamWriter.publish(parameterOnly(SIZE), Flux.fromArray(values)))
             .as(StepVerifier::create)
             .verifyError(MockException.class);
 
-        assertThat(values).extracting(MockParameter::refCnt).containsOnly(0);
+        assertThat(values).extracting(MockMySqlParameter::refCnt).containsOnly(0);
     }
 
     @Test
     void publishNothing() {
-        MockParameter[] values = new MockParameter[SIZE];
+        MockMySqlParameter[] values = new MockMySqlParameter[SIZE];
 
         for (int i = 0; i < SIZE; ++i) {
-            values[i] = new MockParameter(false);
+            values[i] = new MockMySqlParameter(false);
         }
 
         Flux.from(ParamWriter.publish(parameterOnly(SIZE), Flux.fromArray(values)))
             .as(StepVerifier::create)
             .verifyError(MockException.class);
 
-        assertThat(values).extracting(MockParameter::refCnt).containsOnly(0);
+        assertThat(values).extracting(MockMySqlParameter::refCnt).containsOnly(0);
     }
 
     private static Query parameterOnly(int parameters) {


### PR DESCRIPTION
Motivation:
io.r2dbc.spi provides Parameter interface that might shadow our Parameter interface

Modification:
rename Parameter to MySqlParameter

Result:
Clean up