### PR TITLE
Remove CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,0 @@
-# R2DBC MySQL Changelog
-
-## 0.9.0
-
-### New features
-- Supports r2dbc-spi 0.9.0.RELEASE
-
-### Remove Vulnerabilities
-- Updated various out-of-dated dependencies.


### PR DESCRIPTION
Motivation:
Change log will be logged at the github releases.

Modification:
Remove CHANGELOG.md

Result:
Clean up