### PR TITLE
Remove short lived logger instance

### DIFF
--- a/src/main/java/io/asyncer/r2dbc/mysql/client/ReactorNettyClient.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/client/ReactorNettyClient.java
@@ -96,8 +96,7 @@ final class ReactorNettyClient implements Client {
             connection.addHandlerFirst(SslBridgeHandler.NAME, new SslBridgeHandler(context, ssl));
         }
 
-        if (InternalLoggerFactory.getInstance(ReactorNettyClient.class).isTraceEnabled()) {
-            // Or just use logger.isTraceEnabled()?
+        if (logger.isTraceEnabled()) {
             logger.debug("Connection tracking logging is enabled");
 
             connection.addHandlerFirst(LoggingHandler.class.getSimpleName(),


### PR DESCRIPTION
Motivation:
no need to create logger instance to check `isTraceEnabled()`

Modifications:
Modify to use the existing logger instance

Result:
Less garbage