### PR TITLE
Update Spi version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <java.version>1.8</java.version>
     <maven.surefire.skip>false</maven.surefire.skip>
 
-    <r2dbc-spi.version>0.9.0.RELEASE</r2dbc-spi.version>
+    <r2dbc-spi.version>0.9.1.RELEASE</r2dbc-spi.version>
     <reactor.version>2022.0.4</reactor.version>
     <assertj.version>3.21.0</assertj.version>
     <jmh.version>1.36</jmh.version>


### PR DESCRIPTION
Motivation:
Better use latest 0.9.x of spi

Modifications:
Use r2dbc-spi 0.9.1.RELEASE

Results:
Use latest 0.9.x spi