### PR TITLE
Use Slf4j logger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
@@ -75,7 +76,7 @@
     <assertj.version>3.21.0</assertj.version>
     <jmh.version>1.36</jmh.version>
     <junit.version>5.9.2</junit.version>
-    <logback.version>1.4.5</logback.version>
+    <logback.version>1.3.6</logback.version>
     <mockito.version>4.0.0</mockito.version>
     <mysql.version>8.0.32</mysql.version>
     <testcontainers.version>1.17.6</testcontainers.version>
@@ -84,6 +85,7 @@
     <jackson.version>2.14.2</jackson.version>
     <mbr.version>0.3.0.RELEASE</mbr.version>
     <jsr305.version>3.0.2</jsr305.version>
+    <slf4j.version>2.0.7</slf4j.version>
   </properties>
 
   <dependencyManagement>
@@ -116,6 +118,12 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
+        <scope>compile</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -136,6 +144,10 @@
       <groupId>io.r2dbc</groupId>
       <artifactId>r2dbc-spi</artifactId>
       <version>${r2dbc-spi.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
 
     <dependency>
@@ -429,7 +441,7 @@
                   <executable>java</executable>
                   <arguments>
                     <argument>-classpath</argument>
-                    <classpath />
+                    <classpath/>
                     <argument>org.openjdk.jmh.Main</argument>
                     <argument>.*</argument>
                   </arguments>

--- a/src/main/java/io/asyncer/r2dbc/mysql/Extensions.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/Extensions.java
@@ -17,8 +17,8 @@
 package io.asyncer.r2dbc.mysql;
 
 import io.asyncer.r2dbc.mysql.extension.Extension;
-import reactor.util.Logger;
-import reactor.util.Loggers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -33,7 +33,7 @@ import java.util.function.Consumer;
  */
 final class Extensions {
 
-    private static final Logger logger = Loggers.getLogger(Extensions.class);
+    private static final Logger logger = LoggerFactory.getLogger(Extensions.class);
 
     private static final Extension[] EMPTY = { };
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnection.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnection.java
@@ -31,10 +31,10 @@ import io.r2dbc.spi.IsolationLevel;
 import io.r2dbc.spi.TransactionDefinition;
 import io.r2dbc.spi.ValidationDepth;
 import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.SynchronousSink;
-import reactor.util.Logger;
-import reactor.util.Loggers;
 import reactor.util.annotation.Nullable;
 
 import java.time.DateTimeException;
@@ -53,7 +53,7 @@ import static io.asyncer.r2dbc.mysql.util.AssertUtils.requireValidName;
  */
 public final class MySqlConnection implements Connection, ConnectionState {
 
-    private static final Logger logger = Loggers.getLogger(MySqlConnection.class);
+    private static final Logger logger = LoggerFactory.getLogger(MySqlConnection.class);
 
     private static final int DEFAULT_LOCK_WAIT_TIMEOUT = 50;
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/QueryFlow.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/QueryFlow.java
@@ -54,6 +54,8 @@ import io.netty.util.ReferenceCounted;
 import io.r2dbc.spi.IsolationLevel;
 import io.r2dbc.spi.R2dbcPermissionDeniedException;
 import io.r2dbc.spi.TransactionDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.core.publisher.Flux;
@@ -61,8 +63,6 @@ import reactor.core.publisher.Mono;
 import reactor.core.publisher.Operators;
 import reactor.core.publisher.Sinks;
 import reactor.core.publisher.SynchronousSink;
-import reactor.util.Logger;
-import reactor.util.Loggers;
 import reactor.util.annotation.Nullable;
 import reactor.util.concurrent.Queues;
 
@@ -83,7 +83,7 @@ import java.util.function.Predicate;
  */
 final class QueryFlow {
 
-    static final Logger logger = Loggers.getLogger(QueryFlow.class);
+    static final Logger logger = LoggerFactory.getLogger(QueryFlow.class);
 
     // Metadata EOF message will be not receive in here.
     private static final Predicate<ServerMessage> RESULT_DONE = message -> message instanceof CompleteMessage;
@@ -463,7 +463,7 @@ final class MultiQueryExchangeable extends BaseFluxExchangeable {
  */
 final class PrepareExchangeable extends FluxExchangeable<ServerMessage> {
 
-    private static final Logger logger = Loggers.getLogger(PrepareExchangeable.class);
+    private static final Logger logger = LoggerFactory.getLogger(PrepareExchangeable.class);
 
     private static final int PREPARE_OR_RESET = 1;
 
@@ -747,7 +747,7 @@ final class PrepareExchangeable extends FluxExchangeable<ServerMessage> {
  */
 final class LoginExchangeable extends FluxExchangeable<Void> {
 
-    private static final Logger logger = Loggers.getLogger(LoginExchangeable.class);
+    private static final Logger logger = LoggerFactory.getLogger(LoginExchangeable.class);
 
     private static final Map<String, String> ATTRIBUTES = Collections.emptyMap();
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/QueryLogger.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/QueryLogger.java
@@ -16,15 +16,16 @@
 
 package io.asyncer.r2dbc.mysql;
 
-import reactor.util.Logger;
-import reactor.util.Loggers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Query logger to log queries.
  */
 final class QueryLogger {
 
-    private static final Logger logger = Loggers.getLogger("io.asyncer.r2dbc.mysql.QUERY");
+    private static final Logger logger = LoggerFactory.getLogger("io.asyncer.r2dbc.mysql.QUERY");
 
     static void log(String query) {
         logger.debug("Executing direct query: {}", query);

--- a/src/main/java/io/asyncer/r2dbc/mysql/client/DefaultHostnameVerifier.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/client/DefaultHostnameVerifier.java
@@ -17,8 +17,8 @@
 package io.asyncer.r2dbc.mysql.client;
 
 import io.asyncer.r2dbc.mysql.util.AddressUtils;
-import reactor.util.Logger;
-import reactor.util.Loggers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
@@ -47,7 +47,7 @@ final class DefaultHostnameVerifier implements HostnameVerifier {
 
     static final DefaultHostnameVerifier INSTANCE = new DefaultHostnameVerifier();
 
-    private static final Logger logger = Loggers.getLogger(DefaultHostnameVerifier.class);
+    private static final Logger logger = LoggerFactory.getLogger(DefaultHostnameVerifier.class);
 
     private static final boolean LOG_DEBUG = logger.isDebugEnabled();
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/client/MessageDuplexCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/client/MessageDuplexCodec.java
@@ -38,9 +38,9 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.ReferenceCountUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
-import reactor.util.Logger;
-import reactor.util.Loggers;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -53,7 +53,7 @@ final class MessageDuplexCodec extends ChannelDuplexHandler {
 
     static final String NAME = "R2dbcMySqlMessageDuplexCodec";
 
-    private static final Logger logger = Loggers.getLogger(MessageDuplexCodec.class);
+    private static final Logger logger = LoggerFactory.getLogger(MessageDuplexCodec.class);
 
     private DecodeContext decodeContext = DecodeContext.login();
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/client/ReactorNettyClient.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/client/ReactorNettyClient.java
@@ -27,9 +27,10 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.util.ReferenceCounted;
-import io.netty.util.internal.logging.InternalLoggerFactory;
 import io.r2dbc.spi.R2dbcException;
 import org.reactivestreams.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
@@ -38,8 +39,6 @@ import reactor.core.publisher.Sinks;
 import reactor.core.publisher.SynchronousSink;
 import reactor.netty.Connection;
 import reactor.netty.FutureMono;
-import reactor.util.Logger;
-import reactor.util.Loggers;
 import reactor.util.context.Context;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -54,7 +53,7 @@ import static io.asyncer.r2dbc.mysql.util.AssertUtils.requireNonNull;
  */
 final class ReactorNettyClient implements Client {
 
-    private static final Logger logger = Loggers.getLogger(ReactorNettyClient.class);
+    private static final Logger logger = LoggerFactory.getLogger(ReactorNettyClient.class);
 
     private static final boolean DEBUG_ENABLED = logger.isDebugEnabled();
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/client/SslBridgeHandler.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/client/SslBridgeHandler.java
@@ -31,9 +31,9 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.netty.tcp.SslProvider;
-import reactor.util.Logger;
-import reactor.util.Loggers;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLEngine;
@@ -55,7 +55,7 @@ final class SslBridgeHandler extends ChannelDuplexHandler {
 
     private static final String SSL_NAME = "R2dbcMySqlSslHandler";
 
-    private static final Logger logger = Loggers.getLogger(SslBridgeHandler.class);
+    private static final Logger logger = LoggerFactory.getLogger(SslBridgeHandler.class);
 
     private static final String[] TLS_PROTOCOLS = new String[] {
         TlsVersions.TLS1_3, TlsVersions.TLS1_2, TlsVersions.TLS1_1, TlsVersions.TLS1

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/AbstractLobMySqlParameter.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/AbstractLobMySqlParameter.java
@@ -17,10 +17,10 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.util.Logger;
-import reactor.util.Loggers;
 import reactor.util.annotation.Nullable;
 
 /**
@@ -28,7 +28,7 @@ import reactor.util.annotation.Nullable;
  */
 abstract class AbstractLobMySqlParameter extends AbstractMySqlParameter {
 
-    private static final Logger logger = Loggers.getLogger(AbstractLobMySqlParameter.class);
+    private static final Logger logger = LoggerFactory.getLogger(AbstractLobMySqlParameter.class);
 
     @Override
     public final void dispose() {

--- a/src/main/java/io/asyncer/r2dbc/mysql/message/server/MetadataDecodeContext.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/message/server/MetadataDecodeContext.java
@@ -16,8 +16,8 @@
 
 package io.asyncer.r2dbc.mysql.message.server;
 
-import reactor.util.Logger;
-import reactor.util.Loggers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import reactor.util.annotation.Nullable;
 
 /**
@@ -25,7 +25,7 @@ import reactor.util.annotation.Nullable;
  */
 abstract class MetadataDecodeContext implements DecodeContext {
 
-    private static final Logger logger = Loggers.getLogger(MetadataDecodeContext.class);
+    private static final Logger logger = LoggerFactory.getLogger(MetadataDecodeContext.class);
 
     private final boolean eofDeprecated;
 


### PR DESCRIPTION
Motivation:
Slf4j logger is the standard logging interface in the Java eco system.

Modifications:
Use Slf4j to logging

Result:
Use Slf4j
Remove Reactor dependency
(resolves #43)