### PR TITLE
Support Spi 1.0.0.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <java.version>1.8</java.version>
     <maven.surefire.skip>false</maven.surefire.skip>
 
-    <r2dbc-spi.version>0.9.1.RELEASE</r2dbc-spi.version>
+    <r2dbc-spi.version>1.0.0.RELEASE</r2dbc-spi.version>
     <reactor.version>2022.0.4</reactor.version>
     <assertj.version>3.21.0</assertj.version>
     <jmh.version>1.36</jmh.version>

--- a/src/main/java/io/asyncer/r2dbc/mysql/InsertSyntheticRow.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/InsertSyntheticRow.java
@@ -26,7 +26,6 @@ import io.r2dbc.spi.RowMetadata;
 import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Set;
 
 import static io.asyncer.r2dbc.mysql.util.AssertUtils.requireNonNull;
 
@@ -119,12 +118,6 @@ final class InsertSyntheticRow implements Row, RowMetadata, ColumnMetadata {
     @Override
     public List<ColumnMetadata> getColumnMetadatas() {
         return Collections.singletonList(this);
-    }
-
-    @Override
-    @SuppressWarnings("deprecation")
-    public Set<String> getColumnNames() {
-        return nameSet;
     }
 
     @Override

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlResult.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlResult.java
@@ -59,9 +59,9 @@ public final class MySqlResult implements Result {
 
     private static final Consumer<ReferenceCounted> RELEASE = ReferenceCounted::release;
 
-    private static final BiConsumer<Segment, SynchronousSink<Integer>> ROWS_UPDATED = (segment, sink) -> {
+    private static final BiConsumer<Segment, SynchronousSink<Long>> ROWS_UPDATED = (segment, sink) -> {
         if (segment instanceof UpdateCount) {
-            sink.next((int) ((UpdateCount) segment).value());
+            sink.next(((UpdateCount) segment).value());
         } else if (segment instanceof Message) {
             sink.error(((Message) segment).exception());
         } else if (segment instanceof ReferenceCounted) {
@@ -69,7 +69,7 @@ public final class MySqlResult implements Result {
         }
     };
 
-    private static final BiFunction<Integer, Integer, Integer> SUM = Integer::sum;
+    private static final BiFunction<Long, Long, Long> SUM = Long::sum;
 
     private final Flux<Segment> segments;
 
@@ -78,7 +78,7 @@ public final class MySqlResult implements Result {
     }
 
     @Override
-    public Mono<Integer> getRowsUpdated() {
+    public Mono<Long> getRowsUpdated() {
         return segments.handle(ROWS_UPDATED).reduce(SUM);
     }
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlRowMetadata.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlRowMetadata.java
@@ -23,7 +23,6 @@ import io.r2dbc.spi.RowMetadata;
 import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Set;
 
 import static io.asyncer.r2dbc.mysql.util.AssertUtils.requireNonNull;
 
@@ -102,12 +101,6 @@ final class MySqlRowMetadata implements RowMetadata {
     @Override
     public List<MySqlColumnDescriptor> getColumnMetadatas() {
         return InternalArrays.asImmutableList(originMetadata);
-    }
-
-    @SuppressWarnings("deprecation")
-    @Override
-    public Set<String> getColumnNames() {
-        return nameSet;
     }
 
     @Override

--- a/src/test/java/io/asyncer/r2dbc/mysql/ConnectionIntegrationTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/ConnectionIntegrationTest.java
@@ -188,7 +188,7 @@ class ConnectionIntegrationTest extends IntegrationTestSupport {
                 .thenMany(updateBatch.execute())
                 .concatMap(r -> Mono.from(r.getRowsUpdated()))
                 .collectList()
-                .doOnNext(updated -> assertThat(updated).isEqualTo(Arrays.asList(2, 3)))
+                .doOnNext(updated -> assertThat(updated).isEqualTo(Arrays.asList(2L, 3L)))
                 .thenMany(selectBatch.execute())
                 .concatMap(result -> result.map((row, metadata) -> row.get("value", String.class)))
                 .collectList()
@@ -197,7 +197,7 @@ class ConnectionIntegrationTest extends IntegrationTestSupport {
                 .thenMany(deleteBatch.execute())
                 .concatMap(r -> Mono.from(r.getRowsUpdated()))
                 .collectList()
-                .doOnNext(deleted -> assertThat(deleted).isEqualTo(Arrays.asList(3, 2)))
+                .doOnNext(deleted -> assertThat(deleted).isEqualTo(Arrays.asList(3L, 2L)))
                 .then();
         });
     }

--- a/src/test/java/io/asyncer/r2dbc/mysql/IntegrationTestSupport.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/IntegrationTestSupport.java
@@ -63,7 +63,7 @@ abstract class IntegrationTestSupport {
             .as(StepVerifier::create);
     }
 
-    static Mono<Integer> extractRowsUpdated(Result result) {
+    static Mono<Long> extractRowsUpdated(Result result) {
         return Mono.from(result.getRowsUpdated());
     }
 


### PR DESCRIPTION

Motivation:
r2dbc-spi 1.0.0.RELEASE is released.

Modifications:
Depends on r2dbc-spi 1.0.0.RELEASE
Result#getRowsUpdated() now returns Long (was returned Integer) RowMetadata#getColumnNames() is deleted.

Results:
Support latest r2dbc-spi.