### PR TITLE
Apply Custom package-level not null annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
     <mbr.version>0.3.0.RELEASE</mbr.version>
     <jsr305.version>3.0.2</jsr305.version>
     <slf4j.version>2.0.7</slf4j.version>
+    <java-annotations.version>24.0.1</java-annotations.version>
   </properties>
 
   <dependencyManagement>
@@ -124,6 +125,12 @@
         <version>${slf4j.version}</version>
         <scope>compile</scope>
       </dependency>
+      <dependency>
+        <groupId>org.jetbrains</groupId>
+        <artifactId>annotations</artifactId>
+        <version>${java-annotations.version}</version>
+        <scope>provided</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -148,6 +155,10 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
     </dependency>
 
     <dependency>

--- a/src/main/java/io/asyncer/r2dbc/mysql/ConnectionContext.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/ConnectionContext.java
@@ -20,7 +20,7 @@ import io.asyncer.r2dbc.mysql.codec.CodecContext;
 import io.asyncer.r2dbc.mysql.collation.CharCollation;
 import io.asyncer.r2dbc.mysql.constant.ServerStatuses;
 import io.asyncer.r2dbc.mysql.constant.ZeroDateOption;
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import java.time.ZoneId;
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlColumnDescriptor.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlColumnDescriptor.java
@@ -21,7 +21,6 @@ import io.asyncer.r2dbc.mysql.collation.CharCollation;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.asyncer.r2dbc.mysql.message.server.DefinitionMetadataMessage;
 import io.r2dbc.spi.Nullability;
-import reactor.util.annotation.NonNull;
 
 import static io.asyncer.r2dbc.mysql.util.AssertUtils.require;
 import static io.asyncer.r2dbc.mysql.util.AssertUtils.requireNonNull;
@@ -88,7 +87,6 @@ final class MySqlColumnDescriptor implements MySqlColumnMetadata {
         return name;
     }
 
-    @NonNull
     @Override
     public MySqlTypeMetadata getNativeTypeMetadata() {
         return typeMetadata;
@@ -99,7 +97,6 @@ final class MySqlColumnDescriptor implements MySqlColumnMetadata {
         return nullability;
     }
 
-    @NonNull
     @Override
     public Integer getPrecision() {
         return (int) size;

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlColumnMetadata.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlColumnMetadata.java
@@ -20,7 +20,6 @@ import io.asyncer.r2dbc.mysql.codec.CodecContext;
 import io.asyncer.r2dbc.mysql.collation.CharCollation;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.r2dbc.spi.ColumnMetadata;
-import reactor.util.annotation.NonNull;
 
 /**
  * An abstraction of {@link ColumnMetadata} considers MySQL
@@ -54,7 +53,6 @@ public interface MySqlColumnMetadata extends ColumnMetadata {
      */
     long getNativePrecision();
 
-    @NonNull
     @Override
     default Class<?> getJavaType() {
         return getType().getJavaType();

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnection.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnection.java
@@ -30,12 +30,12 @@ import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.IsolationLevel;
 import io.r2dbc.spi.TransactionDefinition;
 import io.r2dbc.spi.ValidationDepth;
+import org.jetbrains.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.SynchronousSink;
-import reactor.util.annotation.Nullable;
 
 import java.time.DateTimeException;
 import java.time.Duration;

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
@@ -20,7 +20,7 @@ import io.asyncer.r2dbc.mysql.constant.SslMode;
 import io.asyncer.r2dbc.mysql.constant.ZeroDateOption;
 import io.asyncer.r2dbc.mysql.extension.Extension;
 import io.netty.handler.ssl.SslContextBuilder;
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import javax.net.ssl.HostnameVerifier;
 import java.net.Socket;

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactory.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactory.java
@@ -28,8 +28,8 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryMetadata;
+import org.jetbrains.annotations.Nullable;
 import reactor.core.publisher.Mono;
-import reactor.util.annotation.Nullable;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionMetadata.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionMetadata.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql;
 
 import io.r2dbc.spi.ConnectionMetadata;
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import static io.asyncer.r2dbc.mysql.util.AssertUtils.requireNonNull;
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlResult.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlResult.java
@@ -34,11 +34,11 @@ import io.r2dbc.spi.Readable;
 import io.r2dbc.spi.Result;
 import io.r2dbc.spi.Row;
 import io.r2dbc.spi.RowMetadata;
+import org.jetbrains.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.SynchronousSink;
-import reactor.util.annotation.Nullable;
 
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -162,7 +162,7 @@ public final class MySqlResult implements Result {
     }
 
     static MySqlResult toResult(boolean binary, Codecs codecs, ConnectionContext context,
-        @Nullable String generatedKeyName, Flux<ServerMessage> messages) {
+                                @Nullable String generatedKeyName, Flux<ServerMessage> messages) {
         requireNonNull(codecs, "codecs must not be null");
         requireNonNull(context, "context must not be null");
         requireNonNull(messages, "messages must not be null");

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlRow.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlRow.java
@@ -20,7 +20,7 @@ import io.asyncer.r2dbc.mysql.codec.Codecs;
 import io.asyncer.r2dbc.mysql.message.FieldValue;
 import io.r2dbc.spi.Row;
 import io.r2dbc.spi.RowMetadata;
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.ParameterizedType;
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlSslConfiguration.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlSslConfiguration.java
@@ -18,7 +18,7 @@ package io.asyncer.r2dbc.mysql;
 
 import io.asyncer.r2dbc.mysql.constant.SslMode;
 import io.netty.handler.ssl.SslContextBuilder;
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import javax.net.ssl.HostnameVerifier;
 import java.util.Arrays;

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlStatementSupport.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlStatementSupport.java
@@ -16,7 +16,8 @@
 
 package io.asyncer.r2dbc.mysql;
 
-import reactor.util.annotation.Nullable;
+
+import org.jetbrains.annotations.Nullable;
 
 import static io.asyncer.r2dbc.mysql.util.AssertUtils.require;
 import static io.asyncer.r2dbc.mysql.util.AssertUtils.requireNonNull;

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlTransactionDefinition.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlTransactionDefinition.java
@@ -19,7 +19,7 @@ package io.asyncer.r2dbc.mysql;
 import io.r2dbc.spi.IsolationLevel;
 import io.r2dbc.spi.Option;
 import io.r2dbc.spi.TransactionDefinition;
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import java.time.Duration;
 import java.util.Collections;

--- a/src/main/java/io/asyncer/r2dbc/mysql/OptionMapper.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/OptionMapper.java
@@ -18,7 +18,7 @@ package io.asyncer.r2dbc.mysql;
 
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.Option;
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.function.Consumer;

--- a/src/main/java/io/asyncer/r2dbc/mysql/ParameterIndex.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/ParameterIndex.java
@@ -16,7 +16,8 @@
 
 package io.asyncer.r2dbc.mysql;
 
-import reactor.util.annotation.Nullable;
+
+import org.jetbrains.annotations.Nullable;
 
 /**
  * A data class considers indexes of a named parameter. Most case of the relation between parameter name and

--- a/src/main/java/io/asyncer/r2dbc/mysql/ParameterWriter.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/ParameterWriter.java
@@ -16,7 +16,8 @@
 
 package io.asyncer.r2dbc.mysql;
 
-import reactor.util.annotation.Nullable;
+
+import org.jetbrains.annotations.Nullable;
 
 import java.io.Writer;
 import java.math.BigDecimal;

--- a/src/main/java/io/asyncer/r2dbc/mysql/Query.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/Query.java
@@ -16,7 +16,8 @@
 
 package io.asyncer.r2dbc.mysql;
 
-import reactor.util.annotation.Nullable;
+
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/io/asyncer/r2dbc/mysql/QueryFlow.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/QueryFlow.java
@@ -54,6 +54,7 @@ import io.netty.util.ReferenceCounted;
 import io.r2dbc.spi.IsolationLevel;
 import io.r2dbc.spi.R2dbcPermissionDeniedException;
 import io.r2dbc.spi.TransactionDefinition;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.CoreSubscriber;
@@ -63,7 +64,6 @@ import reactor.core.publisher.Mono;
 import reactor.core.publisher.Operators;
 import reactor.core.publisher.Sinks;
 import reactor.core.publisher.SynchronousSink;
-import reactor.util.annotation.Nullable;
 import reactor.util.concurrent.Queues;
 
 import java.time.Duration;
@@ -194,7 +194,7 @@ final class QueryFlow {
      * @return the messages received in response to the login exchange.
      */
     static Mono<Client> login(Client client, SslMode sslMode, String database, String user,
-        @Nullable CharSequence password, ConnectionContext context) {
+                              @Nullable CharSequence password, ConnectionContext context) {
         return client.exchange(new LoginExchangeable(client, sslMode, database, user, password, context))
             .onErrorResume(e -> client.forceClose().then(Mono.error(e)))
             .then(Mono.just(client));

--- a/src/main/java/io/asyncer/r2dbc/mysql/authentication/CachingSha2FastAuthProvider.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/authentication/CachingSha2FastAuthProvider.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.authentication;
 
 import io.asyncer.r2dbc.mysql.collation.CharCollation;
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import static io.asyncer.r2dbc.mysql.constant.Envelopes.TERMINAL;
 import static io.asyncer.r2dbc.mysql.util.AssertUtils.requireNonNull;

--- a/src/main/java/io/asyncer/r2dbc/mysql/authentication/CachingSha2FullAuthProvider.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/authentication/CachingSha2FullAuthProvider.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.authentication;
 
 import io.asyncer.r2dbc.mysql.collation.CharCollation;
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import java.nio.CharBuffer;
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/authentication/MySqlAuthProvider.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/authentication/MySqlAuthProvider.java
@@ -18,7 +18,7 @@ package io.asyncer.r2dbc.mysql.authentication;
 
 import io.asyncer.r2dbc.mysql.collation.CharCollation;
 import io.r2dbc.spi.R2dbcPermissionDeniedException;
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import static io.asyncer.r2dbc.mysql.util.AssertUtils.requireNonNull;
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/authentication/MySqlClearAuthProvider.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/authentication/MySqlClearAuthProvider.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.authentication;
 
 import io.asyncer.r2dbc.mysql.collation.CharCollation;
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import java.nio.CharBuffer;
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/authentication/MySqlNativeAuthProvider.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/authentication/MySqlNativeAuthProvider.java
@@ -17,10 +17,10 @@
 package io.asyncer.r2dbc.mysql.authentication;
 
 import io.asyncer.r2dbc.mysql.collation.CharCollation;
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
-import static io.asyncer.r2dbc.mysql.util.InternalArrays.EMPTY_BYTES;
 import static io.asyncer.r2dbc.mysql.util.AssertUtils.requireNonNull;
+import static io.asyncer.r2dbc.mysql.util.InternalArrays.EMPTY_BYTES;
 
 /**
  * An implementation of {@link MySqlAuthProvider} for type "mysql_native_password".

--- a/src/main/java/io/asyncer/r2dbc/mysql/authentication/NoAuthProvider.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/authentication/NoAuthProvider.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.authentication;
 
 import io.asyncer.r2dbc.mysql.collation.CharCollation;
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import static io.asyncer.r2dbc.mysql.util.InternalArrays.EMPTY_BYTES;
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/authentication/OldAuthProvider.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/authentication/OldAuthProvider.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.authentication;
 
 import io.asyncer.r2dbc.mysql.collation.CharCollation;
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;

--- a/src/main/java/io/asyncer/r2dbc/mysql/authentication/Sha256AuthProvider.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/authentication/Sha256AuthProvider.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql.authentication;
 
 import io.asyncer.r2dbc.mysql.collation.CharCollation;
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import java.nio.CharBuffer;
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/authentication/package-info.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/authentication/package-info.java
@@ -18,7 +18,7 @@
  * Handlers for the various types of MySQL authentication.
  */
 
-@NonNullApi
+@NotNullByDefault
 package io.asyncer.r2dbc.mysql.authentication;
 
-import reactor.util.annotation.NonNullApi;
+import io.asyncer.r2dbc.mysql.internal.NotNullByDefault;

--- a/src/main/java/io/asyncer/r2dbc/mysql/cache/Lru.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/cache/Lru.java
@@ -16,7 +16,8 @@
 
 package io.asyncer.r2dbc.mysql.cache;
 
-import reactor.util.annotation.Nullable;
+
+import org.jetbrains.annotations.Nullable;
 
 import static io.asyncer.r2dbc.mysql.util.AssertUtils.require;
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/cache/PrepareCache.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/cache/PrepareCache.java
@@ -16,7 +16,8 @@
 
 package io.asyncer.r2dbc.mysql.cache;
 
-import reactor.util.annotation.Nullable;
+
+import org.jetbrains.annotations.Nullable;
 
 import java.util.function.IntConsumer;
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/client/Client.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/client/Client.java
@@ -22,11 +22,11 @@ import io.asyncer.r2dbc.mysql.message.client.ClientMessage;
 import io.asyncer.r2dbc.mysql.message.server.ServerMessage;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelOption;
+import org.jetbrains.annotations.Nullable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.SynchronousSink;
 import reactor.netty.tcp.TcpClient;
-import reactor.util.annotation.Nullable;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;

--- a/src/main/java/io/asyncer/r2dbc/mysql/client/RequestQueue.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/client/RequestQueue.java
@@ -16,7 +16,7 @@
 
 package io.asyncer.r2dbc.mysql.client;
 
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 import reactor.util.concurrent.Queues;
 
 import java.util.Queue;

--- a/src/main/java/io/asyncer/r2dbc/mysql/client/RequestTask.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/client/RequestTask.java
@@ -17,10 +17,10 @@
 package io.asyncer.r2dbc.mysql.client;
 
 import io.asyncer.r2dbc.mysql.message.client.ClientMessage;
+import org.jetbrains.annotations.Nullable;
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.MonoSink;
-import reactor.util.annotation.Nullable;
 
 /**
  * A task for execute, propagate errors and release resources.

--- a/src/main/java/io/asyncer/r2dbc/mysql/client/package-info.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/client/package-info.java
@@ -18,7 +18,7 @@
  * The infrastructure for exchanging messages with the server.
  */
 
-@NonNullApi
+@NotNullByDefault
 package io.asyncer.r2dbc.mysql.client;
 
-import reactor.util.annotation.NonNullApi;
+import io.asyncer.r2dbc.mysql.internal.NotNullByDefault;

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/AbstractLobMySqlParameter.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/AbstractLobMySqlParameter.java
@@ -16,12 +16,12 @@
 
 package io.asyncer.r2dbc.mysql.codec;
 
+import org.jetbrains.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.util.annotation.Nullable;
 
 /**
  * Base class considers LOB types (i.e. BLOB, CLOB) for {@link AbstractMySqlParameter} implementations.

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/Codec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/Codec.java
@@ -19,7 +19,7 @@ package io.asyncer.r2dbc.mysql.codec;
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
 import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.netty.buffer.ByteBuf;
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Codec to encode and decode values based on MySQL data binary/text protocol.

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/CodecUtils.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/CodecUtils.java
@@ -19,7 +19,7 @@ package io.asyncer.r2dbc.mysql.codec;
 import io.asyncer.r2dbc.mysql.util.VarIntUtils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/Codecs.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/Codecs.java
@@ -17,10 +17,10 @@
 package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
-import io.asyncer.r2dbc.mysql.message.FieldValue;
 import io.asyncer.r2dbc.mysql.MySqlParameter;
+import io.asyncer.r2dbc.mysql.message.FieldValue;
 import io.netty.buffer.ByteBufAllocator;
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.ParameterizedType;
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/DateTimes.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/DateTimes.java
@@ -20,7 +20,7 @@ import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.asyncer.r2dbc.mysql.constant.ZeroDateOption;
 import io.netty.buffer.ByteBuf;
 import io.r2dbc.spi.R2dbcNonTransientResourceException;
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.ParameterizedType;
 import java.time.LocalDate;

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/DefaultCodecs.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/DefaultCodecs.java
@@ -24,7 +24,7 @@ import io.asyncer.r2dbc.mysql.message.NormalFieldValue;
 import io.asyncer.r2dbc.mysql.util.InternalArrays;
 import io.netty.buffer.ByteBufAllocator;
 import io.r2dbc.spi.Parameter;
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/LocalDateCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/LocalDateCodec.java
@@ -22,8 +22,8 @@ import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import org.jetbrains.annotations.Nullable;
 import reactor.core.publisher.Mono;
-import reactor.util.annotation.Nullable;
 
 import java.time.LocalDate;
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/LocalDateTimeCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/LocalDateTimeCodec.java
@@ -22,8 +22,8 @@ import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import org.jetbrains.annotations.Nullable;
 import reactor.core.publisher.Mono;
-import reactor.util.annotation.Nullable;
 
 import java.lang.reflect.ParameterizedType;
 import java.time.LocalDate;

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/MassiveCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/MassiveCodec.java
@@ -18,7 +18,7 @@ package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
 import io.netty.buffer.ByteBuf;
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/MassiveParametrizedCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/MassiveParametrizedCodec.java
@@ -18,7 +18,7 @@ package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
 import io.netty.buffer.ByteBuf;
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.ParameterizedType;
 import java.util.List;

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/ParametrizedCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/ParametrizedCodec.java
@@ -18,7 +18,7 @@ package io.asyncer.r2dbc.mysql.codec;
 
 import io.asyncer.r2dbc.mysql.MySqlColumnMetadata;
 import io.netty.buffer.ByteBuf;
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.ParameterizedType;
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/ZonedDateTimeCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/ZonedDateTimeCodec.java
@@ -22,8 +22,8 @@ import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import org.jetbrains.annotations.Nullable;
 import reactor.core.publisher.Mono;
-import reactor.util.annotation.Nullable;
 
 import java.lang.reflect.ParameterizedType;
 import java.time.LocalDate;

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/lob/package-info.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/lob/package-info.java
@@ -18,7 +18,7 @@
  * The support of LOB (Blob, Clob).
  */
 
-@NonNullApi
+@NotNullByDefault
 package io.asyncer.r2dbc.mysql.codec.lob;
 
-import reactor.util.annotation.NonNullApi;
+import io.asyncer.r2dbc.mysql.internal.NotNullByDefault;

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/package-info.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/package-info.java
@@ -18,7 +18,7 @@
  * Data codecs for the type that the service provider understands.
  */
 
-@NonNullApi
+@NotNullByDefault
 package io.asyncer.r2dbc.mysql.codec;
 
-import reactor.util.annotation.NonNullApi;
+import io.asyncer.r2dbc.mysql.internal.NotNullByDefault;

--- a/src/main/java/io/asyncer/r2dbc/mysql/collation/MixCharsetTarget.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/collation/MixCharsetTarget.java
@@ -16,7 +16,8 @@
 
 package io.asyncer.r2dbc.mysql.collation;
 
-import reactor.util.annotation.Nullable;
+
+import org.jetbrains.annotations.Nullable;
 
 import java.nio.charset.Charset;
 import java.nio.charset.UnsupportedCharsetException;

--- a/src/main/java/io/asyncer/r2dbc/mysql/collation/package-info.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/collation/package-info.java
@@ -18,7 +18,7 @@
  * Character collations of MySQL.
  */
 
-@NonNullApi
+@NotNullByDefault
 package io.asyncer.r2dbc.mysql.collation;
 
-import reactor.util.annotation.NonNullApi;
+import io.asyncer.r2dbc.mysql.internal.NotNullByDefault;

--- a/src/main/java/io/asyncer/r2dbc/mysql/constant/package-info.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/constant/package-info.java
@@ -18,7 +18,7 @@
  * Constants of the MySQL Client/Server Protocol.
  */
 
-@NonNullApi
+@NotNullByDefault
 package io.asyncer.r2dbc.mysql.constant;
 
-import reactor.util.annotation.NonNullApi;
+import io.asyncer.r2dbc.mysql.internal.NotNullByDefault;

--- a/src/main/java/io/asyncer/r2dbc/mysql/extension/package-info.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/extension/package-info.java
@@ -17,8 +17,7 @@
 /**
  * Extensions for the MySQL driver.
  */
-
-@NonNullApi
+@NotNullByDefault
 package io.asyncer.r2dbc.mysql.extension;
 
-import reactor.util.annotation.NonNullApi;
+import io.asyncer.r2dbc.mysql.internal.NotNullByDefault;

--- a/src/main/java/io/asyncer/r2dbc/mysql/internal/NotNullByDefault.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/internal/NotNullByDefault.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql.internal;
+
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.meta.TypeQualifierDefault;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+/**
+ * Specifies that all parameters and return values of methods within a package should be treated as non-null by
+ * default, unless explicitly annotated with a nullness annotation such as {@link org.jetbrains.annotations.Nullable}.
+ * <p>
+ * This annotation is applied at the package level and affects all types within the annotated package.
+ * <p>
+ * Any nullness annotations explicitly applied to a parameter or return value within a package will override
+ * the default nullness behavior specified by {@link NotNullByDefault}.
+ */
+@Documented
+@TypeQualifierDefault({ ElementType.METHOD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.PACKAGE)
+@NotNull
+public @interface NotNullByDefault {
+}

--- a/src/main/java/io/asyncer/r2dbc/mysql/internal/package-info.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/internal/package-info.java
@@ -15,10 +15,6 @@
  */
 
 /**
- * Cache supports for query parse and statement preparation.
+ * For internal usage Only.
  */
-
-@NotNullByDefault
-package io.asyncer.r2dbc.mysql.cache;
-
-import io.asyncer.r2dbc.mysql.internal.NotNullByDefault;
+package io.asyncer.r2dbc.mysql.internal;

--- a/src/main/java/io/asyncer/r2dbc/mysql/message/client/ParamWriter.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/message/client/ParamWriter.java
@@ -20,9 +20,9 @@ import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.Query;
 import io.asyncer.r2dbc.mysql.util.OperatorUtils;
+import org.jetbrains.annotations.Nullable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.util.annotation.Nullable;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;

--- a/src/main/java/io/asyncer/r2dbc/mysql/message/client/package-info.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/message/client/package-info.java
@@ -18,7 +18,7 @@
  * The messages that are sent from a MySQL client to a MySQL server.
  */
 
-@NonNullApi
+@NotNullByDefault
 package io.asyncer.r2dbc.mysql.message.client;
 
-import reactor.util.annotation.NonNullApi;
+import io.asyncer.r2dbc.mysql.internal.NotNullByDefault;

--- a/src/main/java/io/asyncer/r2dbc/mysql/message/package-info.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/message/package-info.java
@@ -19,7 +19,7 @@
  * server to a MySQL client.
  */
 
-@NonNullApi
+@NotNullByDefault
 package io.asyncer.r2dbc.mysql.message;
 
-import reactor.util.annotation.NonNullApi;
+import io.asyncer.r2dbc.mysql.internal.NotNullByDefault;

--- a/src/main/java/io/asyncer/r2dbc/mysql/message/server/DefinitionMetadataMessage.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/message/server/DefinitionMetadataMessage.java
@@ -21,7 +21,7 @@ import io.asyncer.r2dbc.mysql.ConnectionContext;
 import io.asyncer.r2dbc.mysql.collation.CharCollation;
 import io.asyncer.r2dbc.mysql.util.VarIntUtils;
 import io.netty.buffer.ByteBuf;
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import java.nio.charset.Charset;
 import java.util.Objects;

--- a/src/main/java/io/asyncer/r2dbc/mysql/message/server/ErrorMessage.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/message/server/ErrorMessage.java
@@ -25,7 +25,7 @@ import io.r2dbc.spi.R2dbcPermissionDeniedException;
 import io.r2dbc.spi.R2dbcRollbackException;
 import io.r2dbc.spi.R2dbcTimeoutException;
 import io.r2dbc.spi.R2dbcTransientResourceException;
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;

--- a/src/main/java/io/asyncer/r2dbc/mysql/message/server/MetadataDecodeContext.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/message/server/MetadataDecodeContext.java
@@ -16,9 +16,9 @@
 
 package io.asyncer.r2dbc.mysql.message.server;
 
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import reactor.util.annotation.Nullable;
 
 /**
  * Base class considers {@link DefinitionMetadataMessage} for {@link DecodeContext} implementations.

--- a/src/main/java/io/asyncer/r2dbc/mysql/message/server/PreparedMetadataDecodeContext.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/message/server/PreparedMetadataDecodeContext.java
@@ -16,7 +16,8 @@
 
 package io.asyncer.r2dbc.mysql.message.server;
 
-import reactor.util.annotation.Nullable;
+
+import org.jetbrains.annotations.Nullable;
 
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/message/server/ResultDecodeContext.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/message/server/ResultDecodeContext.java
@@ -16,7 +16,8 @@
 
 package io.asyncer.r2dbc.mysql.message.server;
 
-import reactor.util.annotation.Nullable;
+
+import org.jetbrains.annotations.Nullable;
 
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/message/server/ServerMessageDecoder.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/message/server/ServerMessageDecoder.java
@@ -24,7 +24,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.util.ReferenceCountUtil;
 import io.r2dbc.spi.R2dbcNonTransientResourceException;
 import io.r2dbc.spi.R2dbcPermissionDeniedException;
-import reactor.util.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/io/asyncer/r2dbc/mysql/message/server/SyntheticMetadataMessage.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/message/server/SyntheticMetadataMessage.java
@@ -16,7 +16,8 @@
 
 package io.asyncer.r2dbc.mysql.message.server;
 
-import reactor.util.annotation.Nullable;
+
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.Objects;

--- a/src/main/java/io/asyncer/r2dbc/mysql/message/server/package-info.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/message/server/package-info.java
@@ -18,7 +18,7 @@
  * The messages that are sent from the MySQL server to a MySQL client.
  */
 
-@NonNullApi
+@NotNullByDefault
 package io.asyncer.r2dbc.mysql.message.server;
 
-import reactor.util.annotation.NonNullApi;
+import io.asyncer.r2dbc.mysql.internal.NotNullByDefault;

--- a/src/main/java/io/asyncer/r2dbc/mysql/package-info.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/package-info.java
@@ -18,7 +18,7 @@
  * An implementation of the Reactive Relational Database Connection API for MySQL servers.
  */
 
-@NonNullApi
+@NotNullByDefault
 package io.asyncer.r2dbc.mysql;
 
-import reactor.util.annotation.NonNullApi;
+import io.asyncer.r2dbc.mysql.internal.NotNullByDefault;

--- a/src/main/java/io/asyncer/r2dbc/mysql/util/AssertUtils.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/util/AssertUtils.java
@@ -16,7 +16,8 @@
 
 package io.asyncer.r2dbc.mysql.util;
 
-import reactor.util.annotation.Nullable;
+
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Assertion library for {@literal r2dbc-mysql} implementation.

--- a/src/main/java/io/asyncer/r2dbc/mysql/util/FluxCumulateEnvelope.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/util/FluxCumulateEnvelope.java
@@ -19,13 +19,13 @@ package io.asyncer.r2dbc.mysql.util;
 import io.asyncer.r2dbc.mysql.constant.Envelopes;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import org.jetbrains.annotations.Nullable;
 import org.reactivestreams.Subscription;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxOperator;
 import reactor.core.publisher.Operators;
-import reactor.util.annotation.Nullable;
 import reactor.util.context.Context;
 
 /**

--- a/src/main/java/io/asyncer/r2dbc/mysql/util/package-info.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/util/package-info.java
@@ -18,7 +18,7 @@
  * Utility code used throughout the project.
  */
 
-@NonNullApi
+@NotNullByDefault
 package io.asyncer.r2dbc.mysql.util;
 
-import reactor.util.annotation.NonNullApi;
+import io.asyncer.r2dbc.mysql.internal.NotNullByDefault;

--- a/src/test/java/io/asyncer/r2dbc/mysql/IntegrationTestSupport.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/IntegrationTestSupport.java
@@ -18,11 +18,11 @@ package io.asyncer.r2dbc.mysql;
 
 import io.r2dbc.spi.R2dbcBadGrammarException;
 import io.r2dbc.spi.Result;
+import org.jetbrains.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
-import reactor.util.annotation.Nullable;
 
 import java.time.Duration;
 import java.time.ZoneId;

--- a/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfigurationTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfigurationTest.java
@@ -23,8 +23,8 @@ import io.asyncer.r2dbc.mysql.extension.Extension;
 import io.netty.handler.ssl.SslContextBuilder;
 import org.assertj.core.api.ObjectAssert;
 import org.assertj.core.api.ThrowableTypeAssert;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
-import reactor.util.annotation.Nullable;
 
 import java.time.Duration;
 import java.time.ZoneId;

--- a/src/test/java/io/asyncer/r2dbc/mysql/MySqlNamesTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/MySqlNamesTest.java
@@ -16,8 +16,8 @@
 
 package io.asyncer.r2dbc.mysql;
 
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
-import reactor.util.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.HashSet;

--- a/src/test/java/io/asyncer/r2dbc/mysql/OptionMapperTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/OptionMapperTest.java
@@ -20,8 +20,8 @@ import io.asyncer.r2dbc.mysql.constant.SslMode;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.NoSuchOptionException;
 import io.r2dbc.spi.Option;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
-import reactor.util.annotation.Nullable;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;

--- a/src/test/java/io/asyncer/r2dbc/mysql/QueryIntegrationTestSupport.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/QueryIntegrationTestSupport.java
@@ -20,11 +20,11 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import io.netty.util.ReferenceCountUtil;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.Result;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.util.annotation.Nullable;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 

--- a/src/test/java/io/asyncer/r2dbc/mysql/TimeZoneIntegrationTestSupport.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/TimeZoneIntegrationTestSupport.java
@@ -16,9 +16,9 @@
 
 package io.asyncer.r2dbc.mysql;
 
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
-import reactor.util.annotation.Nullable;
 
 import java.time.Instant;
 import java.time.LocalDateTime;

--- a/src/test/java/io/asyncer/r2dbc/mysql/codec/CodecsTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/codec/CodecsTest.java
@@ -24,8 +24,8 @@ import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.asyncer.r2dbc.mysql.message.FieldValue;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.r2dbc.spi.Nullability;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
-import reactor.util.annotation.Nullable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/io/asyncer/r2dbc/mysql/json/package-info.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/json/package-info.java
@@ -18,7 +18,7 @@
  * The JSON supports, may be a extension library.
  */
 
-@NonNullApi
+@NotNullByDefault
 package io.asyncer.r2dbc.mysql.json;
 
-import reactor.util.annotation.NonNullApi;
+import io.asyncer.r2dbc.mysql.internal.NotNullByDefault;

--- a/src/test/java/io/asyncer/r2dbc/mysql/message/server/ServerMessageDecoderTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/message/server/ServerMessageDecoderTest.java
@@ -20,8 +20,8 @@ import io.asyncer.r2dbc.mysql.ConnectionContextTest;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.assertj.core.api.AbstractObjectAssert;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
-import reactor.util.annotation.Nullable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
Motivation:
Better remove reactor dependencies

Modifications:
Created NotNullByDefault and migrate to it.

Results:
Less reactor dependencies