### PR TITLE
Apply lazy load on MySqlAuthProvider instances

### DIFF
--- a/src/main/java/io/asyncer/r2dbc/mysql/authentication/CachingSha2FastAuthProvider.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/authentication/CachingSha2FastAuthProvider.java
@@ -28,7 +28,9 @@ import static io.asyncer.r2dbc.mysql.util.AssertUtils.requireNonNull;
  */
 final class CachingSha2FastAuthProvider implements MySqlAuthProvider {
 
-    static final CachingSha2FastAuthProvider INSTANCE = new CachingSha2FastAuthProvider();
+    static CachingSha2FastAuthProvider getInstance() {
+        return LazyHolder.INSTANCE;
+    }
 
     private static final String ALGORITHM = "SHA-256";
 
@@ -67,5 +69,10 @@ final class CachingSha2FastAuthProvider implements MySqlAuthProvider {
         return CACHING_SHA2_PASSWORD;
     }
 
-    private CachingSha2FastAuthProvider() { }
+    private CachingSha2FastAuthProvider() {
+    }
+
+    private static class LazyHolder {
+        private static final CachingSha2FastAuthProvider INSTANCE = new CachingSha2FastAuthProvider();
+    }
 }

--- a/src/main/java/io/asyncer/r2dbc/mysql/authentication/MySqlAuthProvider.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/authentication/MySqlAuthProvider.java
@@ -77,17 +77,17 @@ public interface MySqlAuthProvider {
 
         switch (type) {
             case CACHING_SHA2_PASSWORD:
-                return CachingSha2FastAuthProvider.INSTANCE;
+                return CachingSha2FastAuthProvider.getInstance();
             case MYSQL_NATIVE_PASSWORD:
-                return MySqlNativeAuthProvider.INSTANCE;
+                return MySqlNativeAuthProvider.getInstance();
             case MYSQL_CLEAR_PASSWORD:
-                return MySqlClearAuthProvider.INSTANCE;
+                return MySqlClearAuthProvider.getInstance();
             case SHA256_PASSWORD:
-                return Sha256AuthProvider.INSTANCE;
+                return Sha256AuthProvider.getInstance();
             case MYSQL_OLD_PASSWORD:
-                return OldAuthProvider.INSTANCE;
+                return OldAuthProvider.getInstance();
             case NO_AUTH_PROVIDER:
-                return NoAuthProvider.INSTANCE;
+                return NoAuthProvider.getInstance();
         }
 
         throw new R2dbcPermissionDeniedException("Authentication plugin '" + type + "' not found");

--- a/src/main/java/io/asyncer/r2dbc/mysql/authentication/MySqlClearAuthProvider.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/authentication/MySqlClearAuthProvider.java
@@ -29,7 +29,9 @@ import static io.asyncer.r2dbc.mysql.util.AssertUtils.requireNonNull;
  */
 public final class MySqlClearAuthProvider implements MySqlAuthProvider {
 
-    static final MySqlClearAuthProvider INSTANCE = new MySqlClearAuthProvider();
+    static MySqlClearAuthProvider getInstance() {
+        return LazyHolder.INSTANCE;
+    }
 
     @Override
     public boolean isSslNecessary() {
@@ -57,5 +59,10 @@ public final class MySqlClearAuthProvider implements MySqlAuthProvider {
         return MYSQL_CLEAR_PASSWORD;
     }
 
-    private MySqlClearAuthProvider() { }
+    private MySqlClearAuthProvider() {
+    }
+
+    private static class LazyHolder {
+        private static final MySqlClearAuthProvider INSTANCE = new MySqlClearAuthProvider();
+    }
 }

--- a/src/main/java/io/asyncer/r2dbc/mysql/authentication/MySqlNativeAuthProvider.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/authentication/MySqlNativeAuthProvider.java
@@ -27,7 +27,9 @@ import static io.asyncer.r2dbc.mysql.util.InternalArrays.EMPTY_BYTES;
  */
 final class MySqlNativeAuthProvider implements MySqlAuthProvider {
 
-    static final MySqlNativeAuthProvider INSTANCE = new MySqlNativeAuthProvider();
+    static MySqlNativeAuthProvider getInstance() {
+        return LazyHolder.INSTANCE;
+    }
 
     private static final String ALGORITHM = "SHA-1";
 
@@ -65,5 +67,10 @@ final class MySqlNativeAuthProvider implements MySqlAuthProvider {
         return MYSQL_NATIVE_PASSWORD;
     }
 
-    private MySqlNativeAuthProvider() { }
+    private MySqlNativeAuthProvider() {
+    }
+
+    private static class LazyHolder {
+        private static final MySqlNativeAuthProvider INSTANCE = new MySqlNativeAuthProvider();
+    }
 }

--- a/src/main/java/io/asyncer/r2dbc/mysql/authentication/NoAuthProvider.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/authentication/NoAuthProvider.java
@@ -27,7 +27,9 @@ import static io.asyncer.r2dbc.mysql.util.InternalArrays.EMPTY_BYTES;
  */
 final class NoAuthProvider implements MySqlAuthProvider {
 
-    static final NoAuthProvider INSTANCE = new NoAuthProvider();
+    static NoAuthProvider getInstance() {
+        return LazyHolder.INSTANCE;
+    }
 
     @Override
     public boolean isSslNecessary() {
@@ -50,5 +52,10 @@ final class NoAuthProvider implements MySqlAuthProvider {
         return NO_AUTH_PROVIDER;
     }
 
-    private NoAuthProvider() { }
+    private NoAuthProvider() {
+    }
+
+    private static class LazyHolder {
+        private static final NoAuthProvider INSTANCE = new NoAuthProvider();
+    }
 }

--- a/src/main/java/io/asyncer/r2dbc/mysql/authentication/OldAuthProvider.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/authentication/OldAuthProvider.java
@@ -31,7 +31,9 @@ import static io.asyncer.r2dbc.mysql.util.InternalArrays.EMPTY_BYTES;
  */
 final class OldAuthProvider implements MySqlAuthProvider {
 
-    static final OldAuthProvider INSTANCE = new OldAuthProvider();
+    static OldAuthProvider getInstance() {
+        return LazyHolder.INSTANCE;
+    }
 
     private static final int MAX_SALT_LENGTH = 8;
 
@@ -177,5 +179,10 @@ final class OldAuthProvider implements MySqlAuthProvider {
         return ((firstPart & Integer.MAX_VALUE) << Integer.SIZE) | (secondPart & Integer.MAX_VALUE);
     }
 
-    private OldAuthProvider() { }
+    private OldAuthProvider() {
+    }
+
+    private static class LazyHolder {
+        private static final OldAuthProvider INSTANCE = new OldAuthProvider();
+    }
 }

--- a/src/main/java/io/asyncer/r2dbc/mysql/authentication/Sha256AuthProvider.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/authentication/Sha256AuthProvider.java
@@ -29,7 +29,9 @@ import static io.asyncer.r2dbc.mysql.util.AssertUtils.requireNonNull;
  */
 final class Sha256AuthProvider implements MySqlAuthProvider {
 
-    static final Sha256AuthProvider INSTANCE = new Sha256AuthProvider();
+    static Sha256AuthProvider getInstance() {
+        return LazyHolder.INSTANCE;
+    }
 
     @Override
     public boolean isSslNecessary() {
@@ -57,5 +59,10 @@ final class Sha256AuthProvider implements MySqlAuthProvider {
         return SHA256_PASSWORD;
     }
 
-    private Sha256AuthProvider() { }
+    private Sha256AuthProvider() {
+    }
+
+    private static class LazyHolder {
+        private static final Sha256AuthProvider INSTANCE = new Sha256AuthProvider();
+    }
 }


### PR DESCRIPTION
Motivation:
Better load singleton instances when we really need it.

Modifications:
Apply Lazy Load on AuthProviders.

Results:
Less memory footprint.
Resolves #49