### PR TITLE
Remove an unnecessary dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,10 +140,6 @@
       <artifactId>reactor-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.projectreactor.addons</groupId>
-      <artifactId>reactor-extra</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.projectreactor.netty</groupId>
       <artifactId>reactor-netty</artifactId>
     </dependency>


### PR DESCRIPTION
Motivation:
Reactor-extra is defined within the dependencies block but not in use

Modifications:
Remove reactor-extra from dependencies block

Results:
Cleanup