### PR TITLE
Trim POM to remove inactive developers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,16 +45,6 @@
         <role>Mainatainer</role>
       </roles>
     </developer>
-    <developer>
-      <id>mobidick1969</id>
-      <name>Nelson k</name>
-      <email>mobidick(at)gmail.com</email>
-      <url>https://github.com/mobidick1969</url>
-      <roles>
-        <role>Maintainer</role>
-      </roles>
-      <timezone>+9</timezone>
-    </developer>
   </developers>
 
   <inceptionYear>2018</inceptionYear>


### PR DESCRIPTION
Motivation:
To keep the developer list up-to-date.

Modifications:
Remove inactive developers

Result:
POM file is up-to-date.