### PR TITLE
Remove Slf4j dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,6 @@
     <jackson.version>2.14.2</jackson.version>
     <mbr.version>0.3.0.RELEASE</mbr.version>
     <jsr305.version>3.0.2</jsr305.version>
-    <slf4j.version>2.0.7</slf4j.version>
     <java-annotations.version>24.0.1</java-annotations.version>
   </properties>
 
@@ -120,12 +119,6 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>${slf4j.version}</version>
-        <scope>compile</scope>
-      </dependency>
-      <dependency>
         <groupId>org.jetbrains</groupId>
         <artifactId>annotations</artifactId>
         <version>${java-annotations.version}</version>
@@ -147,10 +140,6 @@
       <groupId>io.r2dbc</groupId>
       <artifactId>r2dbc-spi</artifactId>
       <version>${r2dbc-spi.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jetbrains</groupId>
@@ -231,6 +220,12 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>mysql</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/io/asyncer/r2dbc/mysql/Extensions.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/Extensions.java
@@ -17,8 +17,8 @@
 package io.asyncer.r2dbc.mysql;
 
 import io.asyncer.r2dbc.mysql.extension.Extension;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -33,7 +33,7 @@ import java.util.function.Consumer;
  */
 final class Extensions {
 
-    private static final Logger logger = LoggerFactory.getLogger(Extensions.class);
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(Extensions.class);
 
     private static final Extension[] EMPTY = { };
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnection.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnection.java
@@ -26,14 +26,14 @@ import io.asyncer.r2dbc.mysql.message.server.CompleteMessage;
 import io.asyncer.r2dbc.mysql.message.server.ErrorMessage;
 import io.asyncer.r2dbc.mysql.message.server.ServerMessage;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.IsolationLevel;
 import io.r2dbc.spi.TransactionDefinition;
 import io.r2dbc.spi.ValidationDepth;
 import org.jetbrains.annotations.Nullable;
 import org.reactivestreams.Publisher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.SynchronousSink;
 
@@ -53,7 +53,7 @@ import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.requireValidName;
  */
 public final class MySqlConnection implements Connection, ConnectionState {
 
-    private static final Logger logger = LoggerFactory.getLogger(MySqlConnection.class);
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(MySqlConnection.class);
 
     private static final int DEFAULT_LOCK_WAIT_TIMEOUT = 50;
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/QueryFlow.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/QueryFlow.java
@@ -51,12 +51,12 @@ import io.asyncer.r2dbc.mysql.message.server.SyntheticMetadataMessage;
 import io.asyncer.r2dbc.mysql.message.server.SyntheticSslResponseMessage;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.ReferenceCounted;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 import io.r2dbc.spi.IsolationLevel;
 import io.r2dbc.spi.R2dbcPermissionDeniedException;
 import io.r2dbc.spi.TransactionDefinition;
 import org.jetbrains.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import reactor.core.CoreSubscriber;
 import reactor.core.Scannable;
 import reactor.core.publisher.Flux;
@@ -83,7 +83,7 @@ import java.util.function.Predicate;
  */
 final class QueryFlow {
 
-    static final Logger logger = LoggerFactory.getLogger(QueryFlow.class);
+    static final InternalLogger logger = InternalLoggerFactory.getInstance(QueryFlow.class);
 
     // Metadata EOF message will be not receive in here.
     private static final Predicate<ServerMessage> RESULT_DONE = message -> message instanceof CompleteMessage;
@@ -463,7 +463,7 @@ final class MultiQueryExchangeable extends BaseFluxExchangeable {
  */
 final class PrepareExchangeable extends FluxExchangeable<ServerMessage> {
 
-    private static final Logger logger = LoggerFactory.getLogger(PrepareExchangeable.class);
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(PrepareExchangeable.class);
 
     private static final int PREPARE_OR_RESET = 1;
 
@@ -747,7 +747,7 @@ final class PrepareExchangeable extends FluxExchangeable<ServerMessage> {
  */
 final class LoginExchangeable extends FluxExchangeable<Void> {
 
-    private static final Logger logger = LoggerFactory.getLogger(LoginExchangeable.class);
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(LoginExchangeable.class);
 
     private static final Map<String, String> ATTRIBUTES = Collections.emptyMap();
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/QueryLogger.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/QueryLogger.java
@@ -17,15 +17,15 @@
 package io.asyncer.r2dbc.mysql;
 
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 
 /**
  * Query logger to log queries.
  */
 final class QueryLogger {
 
-    private static final Logger logger = LoggerFactory.getLogger("io.asyncer.r2dbc.mysql.QUERY");
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance("io.asyncer.r2dbc.mysql.QUERY");
 
     static void log(String query) {
         logger.debug("Executing direct query: {}", query);

--- a/src/main/java/io/asyncer/r2dbc/mysql/client/DefaultHostnameVerifier.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/client/DefaultHostnameVerifier.java
@@ -17,8 +17,8 @@
 package io.asyncer.r2dbc.mysql.client;
 
 import io.asyncer.r2dbc.mysql.internal.util.AddressUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 
 import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
@@ -47,7 +47,7 @@ final class DefaultHostnameVerifier implements HostnameVerifier {
 
     static final DefaultHostnameVerifier INSTANCE = new DefaultHostnameVerifier();
 
-    private static final Logger logger = LoggerFactory.getLogger(DefaultHostnameVerifier.class);
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(DefaultHostnameVerifier.class);
 
     private static final boolean LOG_DEBUG = logger.isDebugEnabled();
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/client/MessageDuplexCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/client/MessageDuplexCodec.java
@@ -38,8 +38,8 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.ReferenceCountUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 import reactor.core.publisher.Flux;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -53,7 +53,7 @@ final class MessageDuplexCodec extends ChannelDuplexHandler {
 
     static final String NAME = "R2dbcMySqlMessageDuplexCodec";
 
-    private static final Logger logger = LoggerFactory.getLogger(MessageDuplexCodec.class);
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(MessageDuplexCodec.class);
 
     private DecodeContext decodeContext = DecodeContext.login();
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/client/ReactorNettyClient.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/client/ReactorNettyClient.java
@@ -27,10 +27,10 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.util.ReferenceCounted;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 import io.r2dbc.spi.R2dbcException;
 import org.reactivestreams.Subscription;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import reactor.core.CoreSubscriber;
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
@@ -53,7 +53,7 @@ import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.requireNonNull;
  */
 final class ReactorNettyClient implements Client {
 
-    private static final Logger logger = LoggerFactory.getLogger(ReactorNettyClient.class);
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(ReactorNettyClient.class);
 
     private static final boolean DEBUG_ENABLED = logger.isDebugEnabled();
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/client/SslBridgeHandler.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/client/SslBridgeHandler.java
@@ -31,8 +31,8 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 import reactor.netty.tcp.SslProvider;
 
 import javax.net.ssl.HostnameVerifier;
@@ -55,7 +55,7 @@ final class SslBridgeHandler extends ChannelDuplexHandler {
 
     private static final String SSL_NAME = "R2dbcMySqlSslHandler";
 
-    private static final Logger logger = LoggerFactory.getLogger(SslBridgeHandler.class);
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(SslBridgeHandler.class);
 
     private static final String[] TLS_PROTOCOLS = new String[] {
         TlsVersions.TLS1_3, TlsVersions.TLS1_2, TlsVersions.TLS1_1, TlsVersions.TLS1

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/AbstractLobMySqlParameter.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/AbstractLobMySqlParameter.java
@@ -16,10 +16,10 @@
 
 package io.asyncer.r2dbc.mysql.codec;
 
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.jetbrains.annotations.Nullable;
 import org.reactivestreams.Publisher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -28,7 +28,7 @@ import reactor.core.publisher.Mono;
  */
 abstract class AbstractLobMySqlParameter extends AbstractMySqlParameter {
 
-    private static final Logger logger = LoggerFactory.getLogger(AbstractLobMySqlParameter.class);
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(AbstractLobMySqlParameter.class);
 
     @Override
     public final void dispose() {

--- a/src/main/java/io/asyncer/r2dbc/mysql/message/server/MetadataDecodeContext.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/message/server/MetadataDecodeContext.java
@@ -16,16 +16,16 @@
 
 package io.asyncer.r2dbc.mysql.message.server;
 
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.jetbrains.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Base class considers {@link DefinitionMetadataMessage} for {@link DecodeContext} implementations.
  */
 abstract class MetadataDecodeContext implements DecodeContext {
 
-    private static final Logger logger = LoggerFactory.getLogger(MetadataDecodeContext.class);
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(MetadataDecodeContext.class);
 
     private final boolean eofDeprecated;
 


### PR DESCRIPTION
Motivation:
Better to minimize the required dependencies for r2dbc-mysql.

Modifications:
Removed the slf4j dependency from the pom.xml file and made sure project still functions correctly by using Netty InternalLogger.

Result:
Less required dependencies. (addresses #46)