### PR TITLE
Change RetentionPolicy to RUNTIME in NotNullByDefault annotation

### DIFF
--- a/src/main/java/io/asyncer/r2dbc/mysql/internal/NotNullByDefault.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/internal/NotNullByDefault.java
@@ -37,7 +37,7 @@ import java.lang.annotation.Target;
  */
 @Documented
 @TypeQualifierDefault({ ElementType.METHOD, ElementType.PARAMETER })
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PACKAGE)
 @NotNull
 public @interface NotNullByDefault {


### PR DESCRIPTION
Motivation:
The NotNullByDefault annotation was originally set with a RetentionPolicy of CLASS, which means it is only available during compile-time. However, we want it to be available during runtime as well, so we can use it for null-checking in Kotlin.

Modifications:
Changed the RetentionPolicy of the NotNullByDefault annotation from CLASS to RUNTIME.

Result:
The NotNullByDefault annotation can now be used for null-checking in Kotlin during both compile-time and runtime.