### PR TITLE
Use variable to store DB_PASSWORD

### DIFF
--- a/.github/workflows/mysql5-5.yml
+++ b/.github/workflows/mysql5-5.yml
@@ -20,6 +20,6 @@ jobs:
         with:
           mysql version: 5.5
           mysql database: r2dbc
-          mysql root password: ${{ secrets.DB_PASSWORD }}
+          mysql root password: ${{ vars.DB_PASSWORD }}
       - name: Integration test with MySQL 5.5
-        run: ./mvnw -B verify -Dmaven.javadoc.skip=true -Dmaven.surefire.skip=true -Dtest.mysql.password=${{ secrets.DB_PASSWORD }} -Dtest.mysql.version=5.5 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN
+        run: ./mvnw -B verify -Dmaven.javadoc.skip=true -Dmaven.surefire.skip=true -Dtest.mysql.password=${{ vars.DB_PASSWORD }} -Dtest.mysql.version=5.5 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN

--- a/.github/workflows/mysql5-6.yml
+++ b/.github/workflows/mysql5-6.yml
@@ -20,6 +20,6 @@ jobs:
         with:
           mysql version: 5.6
           mysql database: r2dbc
-          mysql root password: ${{ secrets.DB_PASSWORD }}
+          mysql root password: ${{ vars.DB_PASSWORD }}
       - name: Integration test with MySQL 5.6
-        run: ./mvnw -B verify -Dmaven.javadoc.skip=true -Dmaven.surefire.skip=true -Dtest.mysql.password=${{ secrets.DB_PASSWORD }} -Dtest.mysql.version=5.6 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN
+        run: ./mvnw -B verify -Dmaven.javadoc.skip=true -Dmaven.surefire.skip=true -Dtest.mysql.password=${{ vars.DB_PASSWORD }} -Dtest.mysql.version=5.6 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN

--- a/.github/workflows/mysql5-7.yml
+++ b/.github/workflows/mysql5-7.yml
@@ -20,6 +20,6 @@ jobs:
         with:
           mysql version: 5.7
           mysql database: r2dbc
-          mysql root password: ${{ secrets.DB_PASSWORD }}
+          mysql root password: ${{ vars.DB_PASSWORD }}
       - name: Integration test with MySQL 5.7
-        run: ./mvnw -B verify -Dmaven.javadoc.skip=true -Dmaven.surefire.skip=true -Dtest.mysql.password=${{ secrets.DB_PASSWORD }} -Dtest.mysql.version=5.7 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN
+        run: ./mvnw -B verify -Dmaven.javadoc.skip=true -Dmaven.surefire.skip=true -Dtest.mysql.password=${{ vars.DB_PASSWORD }} -Dtest.mysql.version=5.7 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN

--- a/.github/workflows/mysql8-0.yml
+++ b/.github/workflows/mysql8-0.yml
@@ -21,6 +21,6 @@ jobs:
           collation server: utf8mb4_0900_ai_ci
           mysql version: 8.0
           mysql database: r2dbc
-          mysql root password: ${{ secrets.DB_PASSWORD }}
+          mysql root password: ${{ vars.DB_PASSWORD }}
       - name: Integration test with MySQL 8.0
-        run: ./mvnw -B verify -Dmaven.javadoc.skip=true -Dmaven.surefire.skip=true -Dtest.mysql.password=${{ secrets.DB_PASSWORD }} -Dtest.mysql.version=8.0 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN
+        run: ./mvnw -B verify -Dmaven.javadoc.skip=true -Dmaven.surefire.skip=true -Dtest.mysql.password=${{ vars.DB_PASSWORD }} -Dtest.mysql.version=8.0 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN


### PR DESCRIPTION
Motivation:
DB_PASSWORD is not a secret variable since it is used only to test.

Modifications:
Use Github variables to store DB_PASSWORD

Results:
Better Repository Structure.