### PR TITLE
Put organization info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
@@ -34,17 +35,10 @@
     </license>
   </licenses>
 
-  <developers>
-    <developer>
-      <id>jchrys</id>
-      <name>jchrys</name>
-      <email>jchrys(at)me.com</email>
-      <url>https://github.com/jchrys</url>
-      <roles>
-        <role>Mainatainer</role>
-      </roles>
-    </developer>
-  </developers>
+  <organization>
+    <name>asyncer.io</name>
+    <url>https://github.com/asyncer-io/r2dbc-mysql</url>
+  </organization>
 
   <inceptionYear>2018</inceptionYear>
   <scm>
@@ -432,7 +426,7 @@
                   <executable>java</executable>
                   <arguments>
                     <argument>-classpath</argument>
-                    <classpath />
+                    <classpath/>
                     <argument>org.openjdk.jmh.Main</argument>
                     <argument>.*</argument>
                   </arguments>


### PR DESCRIPTION
Motivation:
Using organization in POM reduces effort for maintaining it.

Modifications:
Put organization info and remove developers section.

Results:
Less effort to maintain pom.xml.