### PR TITLE
Adding jobs for Java 11 and Java 17.

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -3,7 +3,7 @@ name: Unit tests
 on: [ pull_request ]
 
 jobs:
-  build:
+  build_java_8:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
@@ -12,6 +12,30 @@ jobs:
         with:
           distribution: temurin
           java-version: 8
+          cache: maven
+      - name: Unit test with Maven
+        run: ./mvnw -B test -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN
+  build_java_11:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Temurin 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
+          cache: maven
+      - name: Unit test with Maven
+        run: ./mvnw -B test -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN
+  build_java_17:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Temurin 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
           cache: maven
       - name: Unit test with Maven
         run: ./mvnw -B test -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN

--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,6 @@
         <version>3.8.1</version>
         <configuration>
           <compilerArgs>
-            <arg>-Werror</arg>
             <arg>-Xlint:all</arg>
             <arg>-Xlint:-options</arg>
             <arg>-Xlint:-processing</arg>


### PR DESCRIPTION
Motivation: Currently compatibility tests are only for Java 8. Need to add more tests for other LTS version Java 11 & 11.

Modifications: Added new jobs for Java v11 & v 17 in unit-tests workflow and removed -WError argument in POM.xml for maven-compiler-plugin to fix failing Java 17 build.

Result: Jobs for Java 8, 11, 17 run to check compatibility

#77 .github/workflows/unit-tests.yml has job for Java 8. As part of this PR adding jobs for Java 11 and Java 17.