### PR TITLE
Added Wrapped interface

### DIFF
--- a/src/main/java/io/asyncer/r2dbc/mysql/Wrapped.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/Wrapped.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql;
+
+/**
+ * Provides a way to access an instance of a wrapped resource and for implementors to expose wrapped resources.
+ *
+ * @param <T> the wrapped resource
+ */
+
+public interface Wrapped<T> {
+	
+	/**
+	 * Used to return an object that implements this interface or a wrapper for that object.
+	 * 
+	 * @return an instance of an object that implements this interface or a wrapper for that object.
+	 */
+	T unwrap();
+
+}


### PR DESCRIPTION
Hi @jchrys,

#65 

EDIT: The Wrapped interface already exists in the io.r2dbc.spi package, I think by support you meant the implementation?

I created the Wrapped optional interface. I'm unsure if I need to implement this anywhere or if it's entirely up to the end user. 

**Motivation:** To add support for the Wrapped optional interface in the R2DBC specification so that we can access an instance of a resource that has been wrapped or for implementers to expose wrapped resources.

**Modification:** Added the Wrapped interface into the io.asyncer.r2dbc.mysql package.

**Result:** We can now access an instance of a resource that has been wrapped or expose wrapped resources.