### PR TITLE
Utilize collationId for MySqlType Identification

### DIFF
--- a/src/main/java/io/asyncer/r2dbc/mysql/message/server/DefinitionMetadataMessage.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/message/server/DefinitionMetadataMessage.java
@@ -178,7 +178,7 @@ public final class DefinitionMetadataMessage implements ServerMessage {
         int collationId = buf.readUnsignedShortLE();
         long size = buf.readUnsignedIntLE();
         short typeId = buf.readUnsignedByte();
-        ColumnDefinition definition = ColumnDefinition.of(buf.readShortLE());
+        ColumnDefinition definition = ColumnDefinition.of(buf.readShortLE(), collationId);
 
         return new DefinitionMetadataMessage(database, table, originTable, column, originColumn, collationId,
             size, typeId, definition, buf.readUnsignedByte());

--- a/src/test/java/io/asyncer/r2dbc/mysql/ColumnDefinitionTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/ColumnDefinitionTest.java
@@ -16,6 +16,7 @@
 
 package io.asyncer.r2dbc.mysql;
 
+import io.asyncer.r2dbc.mysql.collation.CharCollation;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,5 +35,27 @@ class ColumnDefinitionTest {
         assertThat(definition.isUnsigned()).isTrue();
         assertThat(definition.isEnum()).isTrue();
         assertThat(definition.isNotNull()).isTrue();
+    }
+
+    @Test
+    void noSet() {
+        ColumnDefinition definition = ColumnDefinition.of(0);
+
+        assertThat(definition.isBinary()).isFalse();
+        assertThat(definition.isSet()).isFalse();
+        assertThat(definition.isUnsigned()).isFalse();
+        assertThat(definition.isEnum()).isFalse();
+        assertThat(definition.isNotNull()).isFalse();
+
+    }
+
+    @Test
+    void isBinaryUsesCollationId() {
+        ColumnDefinition definition = ColumnDefinition.of(-1, CharCollation.BINARY_ID);
+
+        assertThat(definition.isBinary()).isTrue();
+
+        definition = ColumnDefinition.of(-1, ~CharCollation.BINARY_ID);
+        assertThat(definition.isBinary()).isFalse();
     }
 }


### PR DESCRIPTION
Motivation:
varchar binary, the union of JSON and char binary columns are not being accurately mapped to the appropriate MySqlType.

Modification:
Use collationId(charset id) to identify mysql type.

Result:
Enhanced MySqlType Identification.
Resolves #91 