### PR TITLE
Update GitHub Actions for 0.9.x Version Release

### DIFF
--- a/.github/scripts/release_rollback.sh
+++ b/.github/scripts/release_rollback.sh
@@ -19,6 +19,6 @@ set -e
 TAG=$(grep scm.tag= release.properties | cut -d'=' -f2)
 git remote set-url origin git@github.com:asyncer-io/r2dbc-mysql.git
 git fetch
-git checkout "trunk"
+git checkout "$1"
 ./mvnw -B --file pom.xml release:rollback
 git push origin :"$TAG"

--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -16,7 +16,7 @@ name: DEPLOY_SNAPSHOT
 
 on:
   push:
-    branches: [ "trunk" ]
+    branches: [ "trunk", "0.9" ]
 
 
 jobs:
@@ -58,11 +58,3 @@ jobs:
 
       - name: Deploy Local Staged Artifacts
         run: ./mvnw -B --file pom.xml org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DaltStagingDirectory=/home/runner/local-staging
-
-
-
-
-
-
-
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Rollback Release
         working-directory: ./prepare-workspace/
         if: ${{ failure() }}
-        run: ./.github/scripts/release_rollback.sh
+        run: ./.github/scripts/release_rollback.sh ${{ github.ref_name }}
 
   stage-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Motivation:
We will be releasing 0.9.x versions in parallel with 1.0.x versions.

Modification:
Updated GitHub Actions workflow to accommodate the release of 0.9.x versions.

Result:
GitHub Actions is now prepared for the release of 0.9.x versions.