### PR TITLE
Deprecate SOCKET_TIMEOUT option

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
     .option(PASSWORD, "database-password-in-here") // optional, default null, null means has no password
     .option(DATABASE, "r2dbc") // optional, default null, null means not specifying the database
     .option(CONNECT_TIMEOUT, Duration.ofSeconds(3)) // optional, default null, null means no timeout
-    .option(Option.valueOf("socketTimeout"), Duration.ofSeconds(4)) // optional, default null, null means no timeout
+    .option(Option.valueOf("socketTimeout"), Duration.ofSeconds(4)) // deprecated since 0.9.2, because it has no effect and serves no purpose.
     .option(SSL, true) // optional, default sslMode is "preferred", it will be ignore if sslMode is set
     .option(Option.valueOf("sslMode"), "verify_identity") // optional, default "preferred"
     .option(Option.valueOf("sslCa"), "/path/to/mysql/ca.pem") // required when sslMode is verify_ca or verify_identity, default null, null means has no server CA cert

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
@@ -145,7 +145,12 @@ public final class MySqlConnectionConfiguration {
         return connectTimeout;
     }
 
+    /**
+     * @deprecated  This option has been deprecated as of version 0.9.2, because it has no effect and serves no purpose.
+     * Please remove any references to this option from your code, as it will be removed in a future release.
+     */
     @Nullable
+    @Deprecated
     Duration getSocketTimeout() {
         return socketTimeout;
     }

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
@@ -141,7 +141,10 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
      * TCP socket timeout
      *
      * @since 0.8.3
+     * @deprecated  This option has been deprecated as of version 0.9.2, because it has no effect and serves no purpose.
+     * Please remove any references to this option from your code, as it will be removed in a future release.
      */
+    @Deprecated
     public static final Option<Duration> SOCKET_TIMEOUT = Option.valueOf("socketTimeout");
 
     /**

--- a/src/main/java/io/asyncer/r2dbc/mysql/client/Client.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/client/Client.java
@@ -26,6 +26,8 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.SynchronousSink;
 import reactor.netty.tcp.TcpClient;
+import reactor.util.Logger;
+import reactor.util.Loggers;
 import reactor.util.annotation.Nullable;
 
 import java.net.InetSocketAddress;
@@ -39,6 +41,7 @@ import static io.asyncer.r2dbc.mysql.util.AssertUtils.requireNonNull;
  * An abstraction that wraps the networking part of exchanging methods.
  */
 public interface Client {
+    Logger logger = Loggers.getLogger(Client.class);
 
     /**
      * Perform an exchange of a request message. Calling this method while a previous exchange is active will
@@ -133,8 +136,7 @@ public interface Client {
         }
 
         if (socketTimeout != null) {
-            tcpClient = tcpClient.option(ChannelOption.SO_TIMEOUT,
-                Math.toIntExact(socketTimeout.toMillis()));
+            logger.warn("Socket timeout is not supported by the underlying connection and will be ignored.");
         }
 
         if (address instanceof InetSocketAddress) {


### PR DESCRIPTION
Motivation:
The SOCKET_TIMEOUT option has been identified as a NO-OP, meaning it has no effect on the underlying connection. To reduce confusion and potential issues for users, it is necessary to deprecate this option.

Modification:
Added a deprecation annotation to the SOCKET_TIMEOUT option and included a log warning message to inform users that the option is not supported and will be ignored.

Result:
The SOCKET_TIMEOUT option is now marked as deprecated, and users will be notified with a log warning message if they attempt to use it. This change encourages users to remove any references to SOCKET_TIMEOUT in their code.
