### PR TITLE
Update logback dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <assertj.version>3.21.0</assertj.version>
     <jmh.version>1.36</jmh.version>
     <junit.version>5.9.2</junit.version>
-    <logback.version>1.4.5</logback.version>
+    <logback.version>1.3.6</logback.version>
     <mockito.version>4.0.0</mockito.version>
     <mysql.version>8.0.32</mysql.version>
     <testcontainers.version>1.17.6</testcontainers.version>
@@ -229,7 +229,6 @@
         <version>3.8.1</version>
         <configuration>
           <compilerArgs>
-            <arg>-Werror</arg>
             <arg>-Xlint:all</arg>
             <arg>-Xlint:-options</arg>
             <arg>-Xlint:-processing</arg>


### PR DESCRIPTION
Motivation:
logback 1.4.6 is for Java >= 11. but we need to support Java >= 8.

Modification:
use logback 1.3.6

Result:
Support Java 8