### PR TITLE
Implement Static Badge for Compatibility Info

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ This driver provides the following features:
 This project is currently being maintained by [@jchrys](https://github.com/jchrys), since the previous owner has been inactive. We are committed to keeping this project up-to-date and improving it in collaboration with the community.
 
 ## Version compatibility / Integration tests states
-[![MySQL 5.5 status](https://github.com/asyncer-io/r2dbc-mysql/workflows/MySQL%205.5/badge.svg)](https://github.com/asyncer-io/r2dbc-mysql/actions?query=workflow%3A%22MySQL+5.5%22)
-[![MySQL 5.6 status](https://github.com/asyncer-io/r2dbc-mysql/workflows/MySQL%205.6/badge.svg)](https://github.com/asyncer-io/r2dbc-mysql/actions?query=workflow%3A%22MySQL+5.6%22)
-[![MySQL 5.7 status](https://github.com/asyncer-io/r2dbc-mysql/workflows/MySQL%205.7/badge.svg)](https://github.com/asyncer-io/r2dbc-mysql/actions?query=workflow%3A%22MySQL+5.7%22)
-[![MySQL 8.0 status](https://github.com/asyncer-io/r2dbc-mysql/workflows/MySQL%208.0/badge.svg)](https://github.com/asyncer-io/r2dbc-mysql/actions?query=workflow%3A%22MySQL+8.0%22)
+![MySQL 5.5 status](https://img.shields.io/badge/MySQL%205.5-pass-blue)
+![MySQL 5.6 status](https://img.shields.io/badge/MySQL%205.6-pass-blue)
+![MySQL 5.7 status](https://img.shields.io/badge/MySQL%205.7-pass-blue)
+![MySQL 8.0 status](https://img.shields.io/badge/MySQL%208.0-pass-blue)
 
 In fact, it supports lower versions, in the theory, such as 4.1, 4.0, etc.
 


### PR DESCRIPTION
Motivation:
There is no need to use a dynamic badge for compatibility information, as it may be influenced by unmerged PRs and lead to confusion.

Modification:
Replace the dynamic badge with a static badge for compatibility information.

Result:
Reduced confusion by displaying a more stable representation of compatibility information.