### PR TITLE
Update Readme with latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ However, Docker-certified images do not have these versions lower than 5.5.0, so
 <dependency>
   <groupId>io.asyncer</groupId>
   <artifactId>r2dbc-mysql</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
 </dependency>
 ```
 
@@ -53,7 +53,7 @@ However, Docker-certified images do not have these versions lower than 5.5.0, so
 
 ```groovy
 dependencies {
-    implementation 'io.asyncer:r2dbc-mysql:1.0.0'
+    implementation 'io.asyncer:r2dbc-mysql:1.0.1'
 }
 ```
 
@@ -62,7 +62,7 @@ dependencies {
 ```kotlin
 dependencies {
     // Maybe should to use `compile` instead of `implementation` on the lower version of Gradle.
-    implementation("io.asyncer:r2dbc-mysql:1.0.0")
+    implementation("io.asyncer:r2dbc-mysql:1.0.1")
 }
 ```
 


### PR DESCRIPTION
Motivation:
Released 1.0.1

Modifications:
Replace 1.0.0 to 1.0.1

Result:
up-to-date