### PR TITLE
Add Spring Framework and R2DBC-SPI Compatibility Table

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ This implementation is not intended to be used directly, but rather to be
 used as the backing implementation for a humane client library to
 delegate to. See [R2DBC Homepage](https://r2dbc.io).
 
+## Spring-framework and R2DBC-SPI Compatibility
+Refer to the table below to determine the appropriate version of r2dbc-mysql for your project.
+
+| spring-boot-starter-data-r2dbc | spring-data-r2dbc | r2dbc-spi     | r2dbc-mysql(recommended)     |
+|--------------------------------|-------------------|---------------|------------------------------|
+| 3.0.*                          | 3.0.*             | 1.0.0.RELEASE | io.asyncer:r2dbc-mysql:1.0.1 |
+| 2.7.*                          | 1.5.*             | 0.9.1.RELEASE | io.asyncer:r2dbc-mysql:0.9.2 |
+| 2.6.* and below                | 1.4.* and below   | 0.8.6.RELEASE | dev.miku:r2dbc-mysql:0.8.2   |
+
+## Supported Features
 This driver provides the following features:
 
 - [x] Unix domain socket.


### PR DESCRIPTION
Motivation:
Provide users with a clear reference to select the appropriate version of r2dbc-mysql for their project.

Modifications:
Added a compatibility table to the README.md file, which displays the recommended r2dbc-mysql version for each combination of spring-boot-starter-data-r2dbc, spring-data-r2dbc, and r2dbc-spi versions.

Result:
Users can easily identify the correct r2dbc-mysql version to use based on their project's Spring Framework and R2DBC-SPI versions.