### PR TITLE
Implemented Closeable in MySqlConnectionFactory

### DIFF
--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactory.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactory.java
@@ -26,6 +26,7 @@ import io.asyncer.r2dbc.mysql.constant.SslMode;
 import io.asyncer.r2dbc.mysql.extension.CodecRegistrar;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.unix.DomainSocketAddress;
+import io.r2dbc.spi.Closeable;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryMetadata;
 import org.jetbrains.annotations.Nullable;
@@ -40,9 +41,9 @@ import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.requireNonNull;
 /**
  * An implementation of {@link ConnectionFactory} for creating connections to a MySQL database.
  */
-public final class MySqlConnectionFactory implements ConnectionFactory {
+public final class MySqlConnectionFactory implements ConnectionFactory, Closeable {
 
-    private final Mono<MySqlConnection> client;
+    private Mono<MySqlConnection> client;
 
     private MySqlConnectionFactory(Mono<MySqlConnection> client) {
         this.client = client;
@@ -93,7 +94,7 @@ public final class MySqlConnectionFactory implements ConnectionFactory {
             int prepareCacheSize = configuration.getPrepareCacheSize();
 
             return Client.connect(ssl, address, configuration.isTcpKeepAlive(), configuration.isTcpNoDelay(),
-                context, configuration.getConnectTimeout(), configuration.getSocketTimeout())
+                context, configuration.getConnectTimeout(), null)
                 .flatMap(client -> QueryFlow.login(client, sslMode, database, user, password, context))
                 .flatMap(client -> {
                     ByteBufAllocator allocator = client.getByteBufAllocator();
@@ -107,6 +108,15 @@ public final class MySqlConnectionFactory implements ConnectionFactory {
                         prepareCache, prepare);
                 });
         }));
+    }
+    
+    @Override
+    public Mono<Void> close() {
+    	return Mono.defer(() -> {
+    		this.client = null;
+    		
+        	return Mono.empty();
+    	});
     }
 
     private static final class LazyQueryCache {


### PR DESCRIPTION
@jchrys #66 

I added support for the Closeable interface in MySqlConnectionFactory and I also removed the invocation of the deprecated getSocketTimeout() and replaced it with null in MySqlConnectionFactory. Let me know if there are any problems in the code.

Motivation: MySqlConnectionFactory could benefit from a way to release its resources through implementing the Closeable interface.

Modification: MySqlConnectionFactory now implements Closeable and contains the close() method that will remove the reference to the connection publisher. I removed the final keyword from the client reference so that it can be reassigned. I removed the configuration.getSocketTimeout() parameter from Client.connect in the from() method and replaced it with null.

Result: MySqlConnectionFactory now has a way for users to release its resources.