### PR TITLE
Support multi-host 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 
     <r2dbc-spi.version>1.0.0.RELEASE</r2dbc-spi.version>
     <reactor.version>2022.0.0</reactor.version>
-    <assertj.version>3.21.0</assertj.version>
+    <assertj.version>3.24.2</assertj.version>
     <jmh.version>1.36</jmh.version>
     <junit.version>5.9.2</junit.version>
     <logback.version>1.3.6</logback.version>

--- a/src/main/java/io/asyncer/r2dbc/mysql/HostAndPort.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/HostAndPort.java
@@ -26,8 +26,8 @@ public class HostAndPort {
             if (tmpHost.contains(":")) {
                 hostAddresses.add(
                         new HostAndPort(
-                                tmpHost.substring(0, tmpHost.indexOf(":")),
-                                Integer.parseInt(tmpHost.substring(tmpHost.indexOf(":") + 1))));
+                                tmpHost.substring(0, tmpHost.indexOf(':')),
+                                Integer.parseInt(tmpHost.substring(tmpHost.indexOf(':') + 1))));
             } else {
                 hostAddresses.add(new HostAndPort(tmpHost, portFallback));
             }

--- a/src/main/java/io/asyncer/r2dbc/mysql/HostAndPort.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/HostAndPort.java
@@ -1,0 +1,72 @@
+package io.asyncer.r2dbc.mysql;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public class HostAndPort {
+    private final String host;
+    private final int port;
+
+    public HostAndPort(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    public static List<HostAndPort> from(@Nullable String hosts, int portFallback) {
+        if (null == hosts) {
+            return Collections.emptyList();
+        }
+        List<HostAndPort> hostAddresses = new ArrayList<>();
+        String[] tmpHosts = hosts.split(",");
+        for (String tmpHost : tmpHosts) {
+            if (tmpHost.contains(":")) {
+                hostAddresses.add(
+                        new HostAndPort(
+                                tmpHost.substring(0, tmpHost.indexOf(":")),
+                                Integer.parseInt(tmpHost.substring(tmpHost.indexOf(":") + 1))));
+            } else {
+                hostAddresses.add(new HostAndPort(tmpHost, portFallback));
+            }
+        }
+        return Collections.unmodifiableList(hostAddresses);
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(host, port);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof HostAndPort)) {
+            return false;
+        }
+
+        HostAndPort that = (HostAndPort) o;
+
+        return port == that.port && host.equals(that.host);
+    }
+
+    @Override
+    public String toString() {
+        return "HostAndPort{" +
+               "host='" + host + '\'' +
+               ", port=" + port +
+               '}';
+    }
+}

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
@@ -248,13 +248,13 @@ public final class MySqlConnectionConfiguration {
     @Override
     public String toString() {
         if (unixSocket == null) {
-            return "MySqlConnectionConfiguration{, hosts='{" + Arrays.toString(hosts.toArray()) + "}, ssl=" + ssl +
-                   ", tcpNoDelay=" + tcpNoDelay + ", tcpKeepAlive=" + tcpKeepAlive + ", connectTimeout=" +
-                   connectTimeout + ", socketTimeout=" + socketTimeout + ", serverZoneId=" + serverZoneId +
-                   ", zeroDateOption=" + zeroDateOption + ", user='" + user + '\'' + ", password=" + password +
-                   ", database='" + database + "', preferPrepareStatement=" + preferPrepareStatement +
-                   ", queryCacheSize=" + queryCacheSize + ", prepareCacheSize=" + prepareCacheSize +
-                   ", extensions=" + extensions + '}';
+            return "MySqlConnectionConfiguration{, hosts='{" + Arrays.toString(hosts.toArray()) + "}, haMode=" +
+                   haMode + ", ssl=" + ssl + ", tcpNoDelay=" + tcpNoDelay + ", tcpKeepAlive=" + tcpKeepAlive +
+                   ", connectTimeout=" + connectTimeout + ", socketTimeout=" + socketTimeout +
+                   ", serverZoneId=" + serverZoneId + ", zeroDateOption=" + zeroDateOption + ", user='" + user + '\'' +
+                   ", password=" + password + ", database='" + database +
+                   "', preferPrepareStatement=" + preferPrepareStatement + ", queryCacheSize=" + queryCacheSize +
+                   ", prepareCacheSize=" + prepareCacheSize + ", extensions=" + extensions + '}';
         }
 
         return "MySqlConnectionConfiguration{, unixSocket='" + unixSocket + "', connectTimeout=" +

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactory.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactory.java
@@ -75,11 +75,11 @@ public final class MySqlConnectionFactory implements ConnectionFactory {
 
             if (configuration.isHost()) {
                 ssl = configuration.getSsl();
-                address = InetSocketAddress.createUnresolved(configuration.getDomain(),
-                    configuration.getPort());
+                final HostAndPort host = configuration.getHosts().get(0); // TODO: support multiple hosts
+                address = InetSocketAddress.createUnresolved(host.getHost(), host.getPort());
             } else {
                 ssl = MySqlSslConfiguration.disabled();
-                address = new DomainSocketAddress(configuration.getDomain());
+                address = new DomainSocketAddress(configuration.getUnixSocket());
             }
 
             String database = configuration.getDatabase();

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
@@ -37,6 +37,7 @@ import static io.r2dbc.spi.ConnectionFactoryOptions.DRIVER;
 import static io.r2dbc.spi.ConnectionFactoryOptions.HOST;
 import static io.r2dbc.spi.ConnectionFactoryOptions.PASSWORD;
 import static io.r2dbc.spi.ConnectionFactoryOptions.PORT;
+import static io.r2dbc.spi.ConnectionFactoryOptions.PROTOCOL;
 import static io.r2dbc.spi.ConnectionFactoryOptions.SSL;
 import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
 
@@ -56,6 +57,13 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
      * @since 0.8.1
      */
     public static final Option<String> UNIX_SOCKET = Option.valueOf("unixSocket");
+
+    /**
+     * Option to set the haMode.
+     *
+     * @since 1.0.2
+     */
+    public static final Option<String> HA_MODE = Option.valueOf("haMode");
 
     /**
      * Option to set {@link ZoneId} of server. If it is set, driver will ignore the real time zone of
@@ -278,6 +286,12 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
             .to(builder::host);
         mapper.optional(PORT).asInt()
             .to(builder::port);
+        mapper.optional(PROTOCOL).asString()
+            .to(builder::haMode)
+            .otherwise(() -> mapper.optional(HA_MODE)
+                                   .asString()
+                                   .to(builder::haMode)
+            );
         mapper.optional(SSL).asBoolean()
             .to(isSsl -> builder.sslMode(isSsl ? SslMode.REQUIRED : SslMode.DISABLED));
         mapper.optional(SSL_MODE).as(SslMode.class, id -> SslMode.valueOf(id.toUpperCase()))

--- a/src/main/java/io/asyncer/r2dbc/mysql/constant/HaMode.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/constant/HaMode.java
@@ -1,0 +1,40 @@
+package io.asyncer.r2dbc.mysql.constant;
+
+import org.jetbrains.annotations.Nullable;
+
+public enum HaMode {
+    NONE(HostsCardinality.SINGLE),
+    FALLBACK(HostsCardinality.MULTIPLE),
+    LOADBALANCE(HostsCardinality.ONE_OR_MORE),
+    ;
+
+    private final HostsCardinality hostsCardinality;
+
+    HaMode(HostsCardinality hostsCardinality) {
+        this.hostsCardinality = hostsCardinality;
+    }
+
+    public static HaMode parse(@Nullable String haMode, int hostCardinality) {
+        if (hostCardinality == 1) {
+           if (null == haMode || NONE.name().equalsIgnoreCase(haMode)) {
+               return NONE;
+           }
+        }
+        if (hostCardinality > 1) {
+            if (null == haMode || FALLBACK.name().equalsIgnoreCase(haMode)) {
+                return FALLBACK;
+            }
+            if (LOADBALANCE.name().equalsIgnoreCase(haMode)) {
+                return LOADBALANCE;
+            }
+
+        }
+        throw new IllegalArgumentException("Invalid haMode: " + haMode + ", hostCardinality: " + hostCardinality);
+    }
+
+    public enum HostsCardinality {
+        SINGLE,
+        ONE_OR_MORE,
+        MULTIPLE,
+    }
+}

--- a/src/test/java/io/asyncer/r2dbc/mysql/MySqlTestKitSupport.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/MySqlTestKitSupport.java
@@ -79,8 +79,9 @@ abstract class MySqlTestKitSupport implements TestKit<String> {
     private static JdbcTemplate jdbc(MySqlConnectionConfiguration configuration) {
         HikariDataSource source = new HikariDataSource();
 
-        source.setJdbcUrl(String.format("jdbc:mysql://%s:%d/%s", configuration.getDomain(),
-            configuration.getPort(), configuration.getDatabase()));
+        final HostAndPort host = configuration.getHosts().get(0);  // TODO: support multiple hosts
+        source.setJdbcUrl(String.format("jdbc:mysql://%s:%d/%s", host.getHost(),
+            host.getPort(), configuration.getDatabase()));
         source.setUsername(configuration.getUser());
         source.setPassword(Optional.ofNullable(configuration.getPassword())
             .map(Object::toString).orElse(null));


### PR DESCRIPTION
MySqlConnectionConfiguration
- [x] getHosts() returns `List<HostAndPort>`
- [x] getHaMode() returns parsed `HaMode`

MySqlConnectionConfiguration.Builder
- [x] port(int) sets default Port
- [x] host(String) supports multi-host
- [x] removed `isHost()`. (equivalent to  `unixSocket == null`)
- [x] field `domain` is removed and added `unixSocket` and `host` fields


TODO
- [ ] ADD MultiHostConnection or client that supports HaMode. (expected behavior: when it encounters an error propagate the error to all the task in the request queue and reconnect to appropriate host if needed)
- [ ] ADD Tests for above (Unit and Integration)
- [ ] Won't reconnect or try to recover if connection is explicitly closed

Refs
- mysql-connector-j spec. (https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-multi-host-connections.html)

Common Specs (some are from mysql-connector-j docs)
- Each multi-host connection is a wrapper of the underlying physical connections.
- Each of the underlying physical connections has its own session. Sessions cannot be tracked, shared, or copied, given the MySQL architecture.
- Every switch between physical connections means a switch between sessions.
- Within a transaction boundary, there are no switches between physical connections. Beyond a transaction boundary, there is no guarantee that a switch does not occur.

Fallback
connectionUrl
`r2dbc:pool:mysql:fallback://host:defaultPort,host2:port2/database?propertyName=propertyValue`


LoadBalance
connectionUrl
`r2dbc:pool:mysql:loadbalance://host:defaultPort,host2:port2/database?propertyName=propertyValue`

 



