### PR TITLE
Drain request queue when connection is closed

### DIFF
--- a/src/main/java/io/asyncer/r2dbc/mysql/client/ReactorNettyClient.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/client/ReactorNettyClient.java
@@ -200,14 +200,14 @@ final class ReactorNettyClient implements Client {
                 sink.success();
                 return;
             }
-
-            requestQueue.submit(RequestTask.wrap(sink, Mono.fromRunnable(() -> {
+            requestQueue.dispose();
+            sink.success(Mono.fromRunnable(() -> {
                 Sinks.EmitResult result = requests.tryEmitNext(ExitMessage.INSTANCE);
 
                 if (result != Sinks.EmitResult.OK) {
                     logger.error("Exit message sending failed due to {}, force closing", result);
                 }
-            })));
+            }));
         }).flatMap(Function.identity()).onErrorResume(e -> {
             logger.error("Exit message sending failed, force closing", e);
             return Mono.empty();

--- a/src/test/java/io/asyncer/r2dbc/mysql/ConnectionIntegrationTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/ConnectionIntegrationTest.java
@@ -234,6 +234,17 @@ class ConnectionIntegrationTest extends IntegrationTestSupport {
     }
 
     @Test
+    void errorShouldBePropagated() {
+        illegalArgument(connection -> Flux.merge(
+                                           connection.createStatement("SELECT '1 Result' as result, SLEEP(1)").execute(),
+                                           connection.createStatement("SELECT '2 Result' as result").execute(),
+                                           connection.createStatement("SELECT '3 Result' as result").execute())
+                                   .flatMap(r -> r.map((row, meta) -> row.get(0, Integer.class)))
+        );
+    }
+
+
+    @Test
     void batchCrud() {
         // TODO: spilt it to multiple test cases and move it to BatchIntegrationTest
         String isEven = "id % 2 = 0";

--- a/src/test/java/io/asyncer/r2dbc/mysql/IntegrationTestSupport.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/IntegrationTestSupport.java
@@ -50,6 +50,10 @@ abstract class IntegrationTestSupport {
         process(runner).verifyError(R2dbcBadGrammarException.class);
     }
 
+    void illegalArgument(Function<? super MySqlConnection, Publisher<?>> runner) {
+        process(runner).expectError(IllegalArgumentException.class).verify(Duration.ofSeconds(3));
+    }
+
     Mono<MySqlConnection> create() {
         return connectionFactory.create();
     }


### PR DESCRIPTION
Motivation:
Ensure that the request queue is drained when connection is closed, as there is a chance to remain unprocessed. This situation can prevent errors from being propagated effectively.

Modification:
Implemented proper draining of the request queue and sent an exit mesage.

Result:
The connection is now correctly closed, ensuring the proper handling of requests and preventing any unprocessed errors.