### PR TITLE
Fix request queue delaying

### DIFF
--- a/src/test/java/io/asyncer/r2dbc/mysql/ConnectionIntegrationTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/ConnectionIntegrationTest.java
@@ -234,6 +234,16 @@ class ConnectionIntegrationTest extends IntegrationTestSupport {
     }
 
     @Test
+    void errorPropagteRequestQueue() {
+        illegalArgument(connection -> Flux.merge(
+                                connection.createStatement("SELECT 'Result 1', SLEEP(1)").execute(),
+                                connection.createStatement("SELECT 'Result 2'").execute(),
+                                connection.createStatement("SELECT 'Result 3'").execute()
+                        ).flatMap(result -> result.map((row, meta) -> row.get(0, Integer.class)))
+        );
+    }
+
+    @Test
     void batchCrud() {
         // TODO: spilt it to multiple test cases and move it to BatchIntegrationTest
         String isEven = "id % 2 = 0";

--- a/src/test/java/io/asyncer/r2dbc/mysql/IntegrationTestSupport.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/IntegrationTestSupport.java
@@ -50,6 +50,10 @@ abstract class IntegrationTestSupport {
         process(runner).verifyError(R2dbcBadGrammarException.class);
     }
 
+    void illegalArgument(Function<? super MySqlConnection, Publisher<?>> runner) {
+        process(runner).expectError(IllegalArgumentException.class).verify(Duration.ofSeconds(3));
+    }
+
     Mono<MySqlConnection> create() {
         return connectionFactory.create();
     }


### PR DESCRIPTION
Motivation:
The request queue could contain cancelled tasks, which caused delays and stalls.

Modification:
Implemented Filtered out cancelled tasks from the queue. Fixed state machine.

Result:
The queue now functions better.
Resolves issue #114