### PR TITLE
Remove redundant lambda expression

### DIFF
--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
@@ -47,8 +47,6 @@ public final class MySqlConnectionConfiguration {
      */
     private static final int DEFAULT_PORT = 3306;
 
-    private static final Predicate<String> DEFAULT_SERVER_PREPARE = sql -> false;
-
     /**
      * {@code true} if {@link #domain} is hostname, otherwise {@link #domain} is unix domain socket path.
      */
@@ -685,7 +683,7 @@ public final class MySqlConnectionConfiguration {
          * @since 0.8.1
          */
         public Builder useServerPrepareStatement() {
-            return useServerPrepareStatement(DEFAULT_SERVER_PREPARE);
+            return useServerPrepareStatement((sql) -> false);
         }
 
         /**

--- a/src/main/java/io/asyncer/r2dbc/mysql/client/ReactorNettyClient.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/client/ReactorNettyClient.java
@@ -46,7 +46,6 @@ import reactor.util.context.ContextView;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.require;
@@ -62,8 +61,6 @@ final class ReactorNettyClient implements Client {
     private static final boolean DEBUG_ENABLED = logger.isDebugEnabled();
 
     private static final boolean INFO_ENABLED = logger.isInfoEnabled();
-
-    private static final Consumer<ReferenceCounted> RELEASE = ReferenceCounted::release;
 
     private final Connection connection;
 
@@ -153,7 +150,7 @@ final class ReactorNettyClient implements Client {
                                                                       .doOnSubscribe(ignored -> emitNextRequest(request))
                                                                       .handle(handler)
                                                                       .doOnTerminate(requestQueue))
-                                             .doOnDiscard(ReferenceCounted.class, RELEASE);
+                                             .doOnDiscard(ReferenceCounted.class, ReferenceCounted::release);
 
             requestQueue.submit(RequestTask.wrap(request, sink, responses));
         }).flatMapMany(Function.identity());
@@ -187,7 +184,7 @@ final class ReactorNettyClient implements Client {
                     });
 
             requestQueue.submit(RequestTask.wrap(exchangeable, sink, OperatorUtils.discardOnCancel(responses)
-                .doOnDiscard(ReferenceCounted.class, RELEASE)
+                .doOnDiscard(ReferenceCounted.class, ReferenceCounted::release)
                 .doOnCancel(exchangeable::dispose)));
         }).flatMapMany(Function.identity());
     }

--- a/src/main/java/io/asyncer/r2dbc/mysql/message/client/PreparedExecuteMessage.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/message/client/PreparedExecuteMessage.java
@@ -27,7 +27,6 @@ import reactor.core.publisher.Flux;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.Consumer;
 
 import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.requireNonNull;
 
@@ -58,8 +57,6 @@ public final class PreparedExecuteMessage implements ClientMessage, Disposable {
     private static final int TIMES = 1;
 
     private static final byte EXECUTE_FLAG = 0x17;
-
-    private static final Consumer<MySqlParameter> DISPOSE = MySqlParameter::dispose;
 
     private final int statementId;
 
@@ -131,7 +128,7 @@ public final class PreparedExecuteMessage implements ClientMessage, Disposable {
                 writeTypes(buf, size);
 
                 Flux<ByteBuf> parameters = OperatorUtils.discardOnCancel(Flux.fromArray(values))
-                    .doOnDiscard(MySqlParameter.class, DISPOSE)
+                    .doOnDiscard(MySqlParameter.class, MySqlParameter::dispose)
                     .concatMap(MySqlParameter::publishBinary);
 
                 return Flux.just(buf).concatWith(parameters);


### PR DESCRIPTION
**Motivation:**

See https://github.com/asyncer-io/r2dbc-mysql/issues/124 for more.

**Modification:**

Remove redundant static variables which are used only once and use method reference instead to improve code readability.

**Result:**

Closes https://github.com/asyncer-io/r2dbc-mysql/issues/124