### PR TITLE
Apply lazy load on MySqlAuthProvider instances

### DIFF
--- a/src/main/java/io/asyncer/r2dbc/mysql/authentication/CachingSha2FastAuthProvider.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/authentication/CachingSha2FastAuthProvider.java
@@ -61,7 +61,7 @@ final class CachingSha2FastAuthProvider implements MySqlAuthProvider {
 
     @Override
     public MySqlAuthProvider next() {
-        return CachingSha2FullAuthProvider.INSTANCE;
+        return CachingSha2FullAuthProvider.getInstance();
     }
 
     @Override

--- a/src/main/java/io/asyncer/r2dbc/mysql/authentication/CachingSha2FullAuthProvider.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/authentication/CachingSha2FullAuthProvider.java
@@ -30,7 +30,9 @@ import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.requireNonNull;
  */
 final class CachingSha2FullAuthProvider implements MySqlAuthProvider {
 
-    static final CachingSha2FullAuthProvider INSTANCE = new CachingSha2FullAuthProvider();
+    static CachingSha2FullAuthProvider getInstance() {
+        return LazyHolder.INSTANCE;
+    }
 
     @Override
     public boolean isSslNecessary() {
@@ -60,4 +62,8 @@ final class CachingSha2FullAuthProvider implements MySqlAuthProvider {
     }
 
     private CachingSha2FullAuthProvider() { }
+
+    private static class LazyHolder {
+        private static final CachingSha2FullAuthProvider INSTANCE = new CachingSha2FullAuthProvider();
+    }
 }


### PR DESCRIPTION
Motivation:
Better load singleton instances when we really need it.

Modifications:
Apply Lazy Load on AuthProviders.

Results:
Less memory footprint.