### PR TITLE
SocketTimeout Documentation Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ MySqlConnectionConfiguration configuration = MySqlConnectionConfiguration.builde
     .database("r2dbc") // optional, default null, null means not specifying the database
     .serverZoneId(ZoneId.of("Continent/City")) // optional, default null, null means query server time zone when connection init
     .connectTimeout(Duration.ofSeconds(3)) // optional, default null, null means no timeout
-    .socketTimeout(Duration.ofSeconds(4)) // optional, default null, null means no timeout
+    .socketTimeout(Duration.ofSeconds(4)) // deprecated since 1.0.1, because it has no effect and serves no purpose.
     .sslMode(SslMode.VERIFY_IDENTITY) // optional, default SslMode.PREFERRED
     .sslCa("/path/to/mysql/ca.pem") // required when sslMode is VERIFY_CA or VERIFY_IDENTITY, default null, null means has no server CA cert
     .sslCert("/path/to/mysql/client-cert.pem") // optional, default has no client SSL certificate
@@ -218,7 +218,7 @@ Mono<Connection> connectionMono = Mono.from(connectionFactory.create());
 | password | Any printable string | Optional, default no password | The password of the MySQL database user |
 | database | A valid MySQL database name | Optional, default does not initialize database | Database used by the MySQL connection |
 | connectTimeout | A `Duration` which must be positive duration | Optional, default has no timeout | TCP connect timeout |
-| socketTimeout | A `Duration` which must be positive duration | Optional, default has no timeout | TCP socket timeout |
+| socketTimeout | A `Duration` which must be positive duration | Deprecated since 1.0.1 | TCP socket timeout |
 | serverZoneId | An id of `ZoneId` | Optional, default query time zone when connection init | Server time zone id |
 | tcpKeepAlive | `true` or `false` | Optional, default disabled | Controls TCP KeepAlive |
 | tcpNoDelay | `true` or `false` | Optional, default disabled | Controls TCP NoDelay |

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
@@ -443,6 +443,8 @@ public final class MySqlConnectionConfiguration {
          * @param socketTimeout the socket timeout, or {@code null} if has no timeout.
          * @return this {@link Builder}.
          * @since 0.8.6
+         * @deprecated This option has been deprecated as of version 1.0.1, because it has no effect and
+         * serves no purpose.
          */
         public Builder socketTimeout(@Nullable Duration socketTimeout) {
             this.socketTimeout = socketTimeout;


### PR DESCRIPTION
Motivation:
The SocketTimeout option has been deprecated, but the documentation does not reflect this accurately.

Modification:
Update the documentation.

Result:
Cleaned up.