### PR TITLE
Warn connection unexpectedly closed

### DIFF
--- a/src/main/java/io/asyncer/r2dbc/mysql/client/ReactorNettyClient.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/client/ReactorNettyClient.java
@@ -305,10 +305,10 @@ final class ReactorNettyClient implements Client {
         STATE_UPDATER.set(this, ST_CLOSED);
 
         if (oldState != ST_CLOSING) {
-            logger.debug("Connection has been closed by peer");
+            logger.warn("Connection unexpectedly closed");
             drainError(ClientExceptions.unexpectedClosed());
         } else {
-            logger.debug("Connection has been closed");
+            logger.debug("Connection closed");
             drainError(ClientExceptions.expectedClosed());
         }
     }


### PR DESCRIPTION
Motivation:
To enhance the debugging experience, warning when a connection is unexpectedly closed.

Modifications:
Changed the log level to "warn" for unexpected connection closures

Result:
Improved log