### PR TITLE
Added Support for providing configuration option for supplying password function

### DIFF
--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
@@ -21,7 +21,7 @@ import io.asyncer.r2dbc.mysql.constant.ZeroDateOption;
 import io.asyncer.r2dbc.mysql.extension.Extension;
 import io.netty.handler.ssl.SslContextBuilder;
 import org.jetbrains.annotations.Nullable;
-import reactor.core.publisher.Mono;
+import org.reactivestreams.Publisher;
 
 import javax.net.ssl.HostnameVerifier;
 import java.net.Socket;
@@ -33,7 +33,6 @@ import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.require;
 import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.requireNonNull;
@@ -93,14 +92,14 @@ public final class MySqlConnectionConfiguration {
     private final int prepareCacheSize;
 
     private final Extensions extensions;
-    private final Supplier<Mono<String>> passwordSupplier;
+    private final Publisher<String> passwordSupplier;
 
     private MySqlConnectionConfiguration(boolean isHost, String domain, int port, MySqlSslConfiguration ssl,
         boolean tcpKeepAlive, boolean tcpNoDelay, @Nullable Duration connectTimeout,
         @Nullable Duration socketTimeout, ZeroDateOption zeroDateOption, @Nullable ZoneId serverZoneId,
         String user, @Nullable CharSequence password, @Nullable String database,
         @Nullable Predicate<String> preferPrepareStatement, int queryCacheSize, int prepareCacheSize,
-        Extensions extensions, @Nullable Supplier<Mono<String>> passwordSupplier) {
+        Extensions extensions, @Nullable Publisher<String> passwordSupplier) {
         this.isHost = isHost;
         this.domain = domain;
         this.port = port;
@@ -208,7 +207,7 @@ public final class MySqlConnectionConfiguration {
         return extensions;
     }
 
-    Supplier<Mono<String>> getPasswordSupplier() {
+    Publisher<String> getPasswordSupplier() {
         return passwordSupplier;
     }
 
@@ -336,7 +335,7 @@ public final class MySqlConnectionConfiguration {
         private final List<Extension> extensions = new ArrayList<>();
 
         @Nullable
-        private Supplier<Mono<String>> passwordSupplier;
+        private Publisher<String> passwordSupplier;
 
         /**
          * Builds an immutable {@link MySqlConnectionConfiguration} with current options.
@@ -795,7 +794,7 @@ public final class MySqlConnectionConfiguration {
          * @param passwordSupplier function to retrieve password before making connection.
          * @return this {@link Builder}.
          */
-        public Builder passwordSupplier(Supplier<Mono<String>> passwordSupplier) {
+        public Builder passwordSupplier(Publisher<String> passwordSupplier) {
             this.passwordSupplier = passwordSupplier;
             return this;
         }

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
@@ -239,14 +239,15 @@ public final class MySqlConnectionConfiguration {
             Objects.equals(preferPrepareStatement, that.preferPrepareStatement) &&
             queryCacheSize == that.queryCacheSize &&
             prepareCacheSize == that.prepareCacheSize &&
-            extensions.equals(that.extensions);
+            extensions.equals(that.extensions) &&
+            Objects.equals(passwordSupplier, that.passwordSupplier);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(isHost, domain, port, ssl, tcpKeepAlive, tcpNoDelay,
             connectTimeout, socketTimeout, serverZoneId, zeroDateOption, user, password, database,
-            preferPrepareStatement, queryCacheSize, prepareCacheSize, extensions);
+            preferPrepareStatement, queryCacheSize, prepareCacheSize, extensions, passwordSupplier);
     }
 
     @Override
@@ -258,7 +259,7 @@ public final class MySqlConnectionConfiguration {
                 ", zeroDateOption=" + zeroDateOption + ", user='" + user + '\'' + ", password=" + password +
                 ", database='" + database + "', preferPrepareStatement=" + preferPrepareStatement +
                 ", queryCacheSize=" + queryCacheSize + ", prepareCacheSize=" + prepareCacheSize +
-                ", extensions=" + extensions + '}';
+                ", extensions=" + extensions + ", passwordSupplier="+ passwordSupplier + '}';
         }
 
         return "MySqlConnectionConfiguration{, unixSocket='" + domain + "', connectTimeout=" +
@@ -266,7 +267,7 @@ public final class MySqlConnectionConfiguration {
             ", zeroDateOption=" + zeroDateOption + ", user='" + user + "', password=" + password +
             ", database='" + database + "', preferPrepareStatement=" + preferPrepareStatement +
             ", queryCacheSize=" + queryCacheSize + ", prepareCacheSize=" + prepareCacheSize +
-            ", extensions=" + extensions + '}';
+            ", extensions=" + extensions +  ", passwordSupplier="+ passwordSupplier + '}';
     }
 
     /**

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
@@ -92,6 +92,8 @@ public final class MySqlConnectionConfiguration {
     private final int prepareCacheSize;
 
     private final Extensions extensions;
+
+    @Nullable
     private final Publisher<String> passwordSupplier;
 
     private MySqlConnectionConfiguration(boolean isHost, String domain, int port, MySqlSslConfiguration ssl,
@@ -207,6 +209,7 @@ public final class MySqlConnectionConfiguration {
         return extensions;
     }
 
+    @Nullable
     Publisher<String> getPasswordSupplier() {
         return passwordSupplier;
     }

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactory.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactory.java
@@ -30,13 +30,13 @@ import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryMetadata;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Objects;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.requireNonNull;
 
@@ -94,9 +94,9 @@ public final class MySqlConnectionFactory implements ConnectionFactory {
             Extensions extensions = configuration.getExtensions();
             Predicate<String> prepare = configuration.getPreferPrepareStatement();
             int prepareCacheSize = configuration.getPrepareCacheSize();
-            Supplier<Mono<String>> passwordSupplier = configuration.getPasswordSupplier();
+            Publisher<String> passwordSupplier = configuration.getPasswordSupplier();
             if (Objects.nonNull(passwordSupplier)) {
-                return passwordSupplier.get()
+                return Mono.from(passwordSupplier)
                         .flatMap(token -> getMySqlConnection(
                             configuration, queryCache,
                             ssl, address,

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactory.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactory.java
@@ -125,9 +125,9 @@ public final class MySqlConnectionFactory implements ConnectionFactory {
             final SslMode sslMode,
             final ConnectionContext context,
             final Extensions extensions,
-            final Predicate<String> prepare,
+            @Nullable final Predicate<String> prepare,
             final int prepareCacheSize,
-            final CharSequence password) {
+            @Nullable final CharSequence password) {
         return Client.connect(ssl, address, configuration.isTcpKeepAlive(), configuration.isTcpNoDelay(),
                 context, configuration.getConnectTimeout(), configuration.getSocketTimeout())
             .flatMap(client -> QueryFlow.login(client, sslMode, database, user, password, context))

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
@@ -23,7 +23,7 @@ import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.ConnectionFactoryProvider;
 import io.r2dbc.spi.Option;
-import reactor.core.publisher.Mono;
+import org.reactivestreams.Publisher;
 
 import javax.net.ssl.HostnameVerifier;
 import java.time.Duration;
@@ -211,7 +211,7 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
      * The token is valid for 15 minutes, and this token will be used as password.
      *
      */
-    public static final Option<Supplier<Mono<String>>> PASSWORD_SUPPLIER = Option.valueOf("passwordSupplier");
+    public static final Option<Publisher<String>> PASSWORD_SUPPLIER = Option.valueOf("passwordSupplier");
 
     @Override
     public ConnectionFactory create(ConnectionFactoryOptions options) {
@@ -271,7 +271,7 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
             .to(builder::socketTimeout);
         mapper.optional(DATABASE).asString()
             .to(builder::database);
-        mapper.optional(PASSWORD_SUPPLIER).as(Supplier.class)
+        mapper.optional(PASSWORD_SUPPLIER).as(Publisher.class)
             .to(builder::passwordSupplier);
 
         return builder.build();

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
@@ -30,7 +30,6 @@ import java.time.Duration;
 import java.time.ZoneId;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.requireNonNull;
 import static io.r2dbc.spi.ConnectionFactoryOptions.CONNECT_TIMEOUT;

--- a/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfigurationTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfigurationTest.java
@@ -194,15 +194,14 @@ class MySqlConnectionConfigurationTest {
 
     @Test
     void validPasswordSupplier() {
-        final Supplier<Mono<String>> passwordSupplier = () -> Mono.just("123456");
-        MySqlConnectionConfiguration.builder()
+        final Mono<String> passwordSupplier = Mono.just("123456");
+        Mono.from(MySqlConnectionConfiguration.builder()
                 .host(HOST)
                 .user(USER)
                 .passwordSupplier(passwordSupplier)
                 .autodetectExtensions(false)
                 .build()
-                .getPasswordSupplier()
-                .get()
+                .getPasswordSupplier())
             .as(StepVerifier::create)
             .expectNext("123456")
             .verifyComplete();

--- a/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfigurationTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfigurationTest.java
@@ -25,6 +25,8 @@ import org.assertj.core.api.ObjectAssert;
 import org.assertj.core.api.ThrowableTypeAssert;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import java.time.Duration;
 import java.time.ZoneId;
@@ -32,6 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -187,6 +190,22 @@ class MySqlConnectionConfigurationTest {
             .getExtensions()
             .forEach(Extension.class, list::add);
         assertThat(list).isEmpty();
+    }
+
+    @Test
+    void validPasswordSupplier() {
+        final Supplier<Mono<String>> passwordSupplier = () -> Mono.just("123456");
+        MySqlConnectionConfiguration.builder()
+                .host(HOST)
+                .user(USER)
+                .passwordSupplier(passwordSupplier)
+                .autodetectExtensions(false)
+                .build()
+                .getPasswordSupplier()
+                .get()
+            .as(StepVerifier::create)
+            .expectNext("123456")
+            .verifyComplete();
     }
 
     private static MySqlConnectionConfiguration unixSocketSslMode(SslMode sslMode) {

--- a/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProviderTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProviderTest.java
@@ -24,6 +24,7 @@ import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.Option;
 import org.assertj.core.api.Assert;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSession;
@@ -34,7 +35,9 @@ import java.time.ZoneId;
 import java.util.Collections;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
+import static io.asyncer.r2dbc.mysql.MySqlConnectionFactoryProvider.PASSWORD_SUPPLIER;
 import static io.asyncer.r2dbc.mysql.MySqlConnectionFactoryProvider.USE_SERVER_PREPARE_STATEMENT;
 import static io.r2dbc.spi.ConnectionFactoryOptions.CONNECT_TIMEOUT;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
@@ -390,6 +393,20 @@ class MySqlConnectionFactoryProviderTest {
                 .option(USE_SERVER_PREPARE_STATEMENT, NotPredicate.class.getPackage() + "NonePredicate")
                 .build()));
     }
+
+    @Test
+    void validPasswordSupplier() {
+        final Supplier<Mono<String>> passwordSupplier = () -> Mono.just("123456");
+        ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
+            .option(DRIVER, "mysql")
+            .option(HOST, "127.0.0.1")
+            .option(USER, "root")
+            .option(PASSWORD_SUPPLIER, passwordSupplier)
+            .build();
+
+        assertThat(ConnectionFactories.get(options)).isExactlyInstanceOf(MySqlConnectionFactory.class);
+    }
+
 }
 
 final class MockException extends RuntimeException {

--- a/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProviderTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProviderTest.java
@@ -24,6 +24,7 @@ import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.Option;
 import org.assertj.core.api.Assert;
 import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
 import javax.net.ssl.HostnameVerifier;
@@ -396,7 +397,7 @@ class MySqlConnectionFactoryProviderTest {
 
     @Test
     void validPasswordSupplier() {
-        final Supplier<Mono<String>> passwordSupplier = () -> Mono.just("123456");
+        final Publisher<String> passwordSupplier = Mono.just("123456");
         ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
             .option(DRIVER, "mysql")
             .option(HOST, "127.0.0.1")


### PR DESCRIPTION
Motivation:
Currently r2dbc-mysql does not support IAM based Authentication for authenticating with AWS Aurora RDS database. The way IAM based authentication works is requesting token from AWS RDS for that hostname and username (which is same as AWS IAM Role name). These tokens are valid for 15 minutes, cannot reuse same token after 15 minutes.
By adding configuration option for supplying password function, whenever a new connection is made then password is retrieved using supplier function each time.


Modification:
Modified `MySqlConnectionFactoryProvider` - Added new configurable option.
`Option<Supplier<Mono<String>>> PASSWORD_SUPPLIER = Option.valueOf("passwordSupplier");`
Modified `MySqlConnectionConfiguration` - Added the new configuration for Password Supplier function.
`Supplier<Mono<String>> passwordSupplier;`
Modified `MySqlConnectionFactory` - Retrieves Password Supplier function from configuration, and then retrieves password each time connection factory is created.
 

Result:
Users can provide a supplier function using `PASSWORD_SUPPLIER` option. This function will be used for retrieving password/token each time. 

```
public ConnectionFactory writeConnectionFactory(final RdsTokenGenerator rdsTokenGenerator) {
        return ConnectionFactories.get(ConnectionFactoryOptions.builder()
            .option(ConnectionFactoryOptions.DRIVER, "mysql")
            .option(ConnectionFactoryOptions.HOST, "Hostname of AWS Aurora DB instance")
            .option(ConnectionFactoryOptions.PORT, 3306)
            .option(ConnectionFactoryOptions.USER, "IAM ROLE Having access to RDS")
            .option(MySqlConnectionFactoryProvider.PASSWORD_SUPPLIER, rdsTokenGenerator::generateAuthenticationToken)
            .build());
    }
```

Example of `RdsTokenGenerator`
```
public class RdsTokenGenerator {
    public Mono<String> generateAuthenticationToken() {
        return Mono.fromCallable(() -> RdsUtilities.builder()
            .credentialsProvider(DefaultCredentialsProvider.create())
            .region(Region.US_EAST_1)
            .build();
            .generateAuthenticationToken((builder) ->
                builder
                    .hostname(hostname)
                    .port(port)
                    .username(user)
            ))
            .flatMap(token -> LOGGER.info("Retrieved token from RdsUtilities")
                .then(Mono.just(token)))
            .subscribeOn(Schedulers.boundedElastic());
    }

}
```