### PR TITLE
Support `createDatabaseIfNotExist`

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
     .option(PORT, 3306)  // optional, default 3306
     .option(PASSWORD, "database-password-in-here") // optional, default null, null means has no password
     .option(DATABASE, "r2dbc") // optional, default null, null means not specifying the database
+    .option(Option.valueOf("createDatabaseIfNotExist"), true) // optional, default false, create database if not exist (since 1.0.6 / 0.9.7)
     .option(CONNECT_TIMEOUT, Duration.ofSeconds(3)) // optional, default null, null means no timeout
     .option(Option.valueOf("socketTimeout"), Duration.ofSeconds(4)) // deprecated since 1.0.1, because it has no effect and serves no purpose.
     .option(SSL, true) // optional, default sslMode is "preferred", it will be ignore if sslMode is set
@@ -172,6 +173,7 @@ MySqlConnectionConfiguration configuration = MySqlConnectionConfiguration.builde
     .port(3306) // optional, default 3306
     .password("database-password-in-here") // optional, default null, null means has no password
     .database("r2dbc") // optional, default null, null means not specifying the database
+    .createDatabaseIfNotExist(true) // optional, default false, create database if not exist (since 1.0.6 / 0.9.7)
     .serverZoneId(ZoneId.of("Continent/City")) // optional, default null, null means query server time zone when connection init
     .connectTimeout(Duration.ofSeconds(3)) // optional, default null, null means no timeout
     .socketTimeout(Duration.ofSeconds(4)) // deprecated since 1.0.1, because it has no effect and serves no purpose.
@@ -221,6 +223,7 @@ Mono<Connection> connectionMono = Mono.from(connectionFactory.create());
 | user | A valid MySQL username and not be empty | Required | Who wants to connect to the MySQL database |
 | password | Any printable string | Optional, default no password | The password of the MySQL database user |
 | database | A valid MySQL database name | Optional, default does not initialize database | Database used by the MySQL connection |
+| createDatabaseIfNotExist | `true` or `false` | Optional, default `false` | Create database if not exist |
 | connectTimeout | A `Duration` which must be positive duration | Optional, default has no timeout | TCP connect timeout |
 | socketTimeout | A `Duration` which must be positive duration | Deprecated since 1.0.1 | TCP socket timeout |
 | serverZoneId | An id of `ZoneId` | Optional, default query time zone when connection init | Server time zone id |

--- a/src/main/java/io/asyncer/r2dbc/mysql/Capability.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/Capability.java
@@ -26,6 +26,8 @@ public final class Capability {
 
     /**
      * Can use long password.
+     * <p>
+     * TODO: Reinterpret it as {@code CLIENT_MYSQL} to support MariaDB 10.2 and above.
      */
     private static final int LONG_PASSWORD = 1;
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactory.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactory.java
@@ -28,7 +28,6 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryMetadata;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
@@ -86,6 +85,7 @@ public final class MySqlConnectionFactory implements ConnectionFactory {
             }
 
             String database = configuration.getDatabase();
+            boolean createDbIfNotExist = configuration.isCreateDatabaseIfNotExist();
             String user = configuration.getUser();
             CharSequence password = configuration.getPassword();
             SslMode sslMode = ssl.getSslMode();
@@ -95,32 +95,36 @@ public final class MySqlConnectionFactory implements ConnectionFactory {
             Predicate<String> prepare = configuration.getPreferPrepareStatement();
             int prepareCacheSize = configuration.getPrepareCacheSize();
             Publisher<String> passwordPublisher = configuration.getPasswordPublisher();
+
             if (Objects.nonNull(passwordPublisher)) {
-                return Mono.from(passwordPublisher)
-                        .flatMap(token -> getMySqlConnection(
-                            configuration, queryCache,
-                            ssl, address,
-                            database, user,
-                            sslMode, context,
-                            extensions, prepare,
-                            prepareCacheSize, token));
+                return Mono.from(passwordPublisher).flatMap(token -> getMySqlConnection(
+                    configuration, queryCache,
+                    ssl, address,
+                    database, createDbIfNotExist,
+                    user, sslMode, context,
+                    extensions, prepare,
+                    prepareCacheSize, token
+                ));
             }
-            return getMySqlConnection(configuration, queryCache,
+
+            return getMySqlConnection(
+                configuration, queryCache,
                 ssl, address,
-                database, user,
-                sslMode, context,
+                database, createDbIfNotExist,
+                user, sslMode, context,
                 extensions, prepare,
-                prepareCacheSize, password);
+                prepareCacheSize, password
+            );
         }));
     }
 
-    @NotNull
     private static Mono<MySqlConnection> getMySqlConnection(
             final MySqlConnectionConfiguration configuration,
             final LazyQueryCache queryCache,
             final MySqlSslConfiguration ssl,
             final SocketAddress address,
             final String database,
+            final boolean createDbIfNotExist,
             final String user,
             final SslMode sslMode,
             final ConnectionContext context,
@@ -130,16 +134,21 @@ public final class MySqlConnectionFactory implements ConnectionFactory {
             @Nullable final CharSequence password) {
         return Client.connect(ssl, address, configuration.isTcpKeepAlive(), configuration.isTcpNoDelay(),
                 context, configuration.getConnectTimeout(), configuration.getSocketTimeout())
-            .flatMap(client -> QueryFlow.login(client, sslMode, database, user, password, context))
+            .flatMap(client -> {
+                // Lazy init database after handshake/login
+                String db = createDbIfNotExist ? "" : database;
+                return QueryFlow.login(client, sslMode, db, user, password, context);
+            })
             .flatMap(client -> {
                 ByteBufAllocator allocator = client.getByteBufAllocator();
                 CodecsBuilder builder = Codecs.builder(allocator);
                 PrepareCache prepareCache = Caches.createPrepareCache(prepareCacheSize);
+                String db = createDbIfNotExist ? database : "";
 
                 extensions.forEach(CodecRegistrar.class, registrar ->
                     registrar.register(allocator, builder));
 
-                return MySqlConnection.init(client, builder.build(), context, queryCache.get(),
+                return MySqlConnection.init(client, builder.build(), context, db, queryCache.get(),
                     prepareCache, prepare);
             });
     }

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
@@ -163,6 +163,14 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
     public static final Option<Boolean> TCP_NO_DELAY = Option.valueOf("tcpNoDelay");
 
     /**
+     * Enable/Disable database creation if not exist.
+     *
+     * @since 1.0.6
+     */
+    public static final Option<Boolean> CREATE_DATABASE_IF_NOT_EXIST =
+        Option.valueOf("createDatabaseIfNotExist");
+
+    /**
      * Enable server preparing for parametrized statements and prefer server preparing simple statements.
      * <p>
      * The value can be a {@link Boolean}. If it is {@code true}, driver will use server preparing for
@@ -270,8 +278,10 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
             .to(builder::socketTimeout);
         mapper.optional(DATABASE).asString()
             .to(builder::database);
+        mapper.optional(CREATE_DATABASE_IF_NOT_EXIST).asBoolean()
+            .to(builder::createDatabaseIfNotExist);
         mapper.optional(PASSWORD_PUBLISHER).as(Publisher.class)
-              .to(builder::passwordPublisher);
+            .to(builder::passwordPublisher);
 
         return builder.build();
     }

--- a/src/main/java/io/asyncer/r2dbc/mysql/QueryFlow.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/QueryFlow.java
@@ -888,6 +888,7 @@ final class LoginExchangeable extends FluxExchangeable<Void> {
 
         builder.disableDatabasePinned();
         builder.disableCompression();
+        // TODO: support LOAD DATA LOCAL INFILE
         builder.disableLoadDataInfile();
         builder.disableIgnoreAmbiguitySpace();
         builder.disableInteractiveTimeout();

--- a/src/main/java/io/asyncer/r2dbc/mysql/message/client/InitDbMessage.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/message/client/InitDbMessage.java
@@ -1,0 +1,19 @@
+package io.asyncer.r2dbc.mysql.message.client;
+
+import io.asyncer.r2dbc.mysql.ConnectionContext;
+import io.netty.buffer.ByteBuf;
+
+public final class InitDbMessage extends ScalarClientMessage {
+
+    private static final byte FLAG = 0x02;
+
+    private final String database;
+
+    public InitDbMessage(String database) { this.database = database; }
+
+    @Override
+    protected void writeTo(ByteBuf buf, ConnectionContext context) {
+        // RestOfPacketString, no need terminal or length
+        buf.writeByte(FLAG).writeCharSequence(database, context.getClientCollation().getCharset());
+    }
+}

--- a/src/test/java/io/asyncer/r2dbc/mysql/ConnectionIntegrationTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/ConnectionIntegrationTest.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ConnectionIntegrationTest extends IntegrationTestSupport {
 
     ConnectionIntegrationTest() {
-        super(configuration(false, null, null));
+        super(configuration("r2dbc", false, false, null, null));
     }
 
     @Test

--- a/src/test/java/io/asyncer/r2dbc/mysql/InitDbIntegrationTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/InitDbIntegrationTest.java
@@ -1,0 +1,35 @@
+package io.asyncer.r2dbc.mysql;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@code createDatabaseIfNotExist}.
+ */
+class InitDbIntegrationTest extends IntegrationTestSupport {
+
+    private static final String DATABASE = "test-" + ThreadLocalRandom.current().nextInt(10000);
+
+    InitDbIntegrationTest() {
+        super(configuration(
+            DATABASE, true, false,
+            null, null
+        ));
+    }
+
+    @Test
+    void shouldCreateDatabase() {
+        complete(conn -> conn.createStatement("SHOW DATABASES")
+            .execute()
+            .flatMap(it -> it.map((row, rowMetadata) -> row.get(0, String.class)))
+            .collect(Collectors.toSet())
+            .doOnNext(it -> assertThat(it).contains(DATABASE))
+            .thenMany(conn.createStatement("DROP DATABASE `" + DATABASE + "`")
+                .execute()
+                .flatMap(MySqlResult::getRowsUpdated)));
+    }
+}

--- a/src/test/java/io/asyncer/r2dbc/mysql/IntegrationTestSupport.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/IntegrationTestSupport.java
@@ -71,8 +71,10 @@ abstract class IntegrationTestSupport {
         return Mono.from(result.getRowsUpdated());
     }
 
-    static MySqlConnectionConfiguration configuration(boolean autodetectExtensions,
-        @Nullable ZoneId serverZoneId, @Nullable Predicate<String> preferPrepared) {
+    static MySqlConnectionConfiguration configuration(
+        String database, boolean createDatabaseIfNotExist, boolean autodetectExtensions,
+        @Nullable ZoneId serverZoneId, @Nullable Predicate<String> preferPrepared
+    ) {
         String password = System.getProperty("test.mysql.password");
 
         assertThat(password).withFailMessage("Property test.mysql.password must exists and not be empty")
@@ -84,7 +86,8 @@ abstract class IntegrationTestSupport {
             .connectTimeout(Duration.ofSeconds(3))
             .user("root")
             .password(password)
-            .database("r2dbc")
+            .database(database)
+            .createDatabaseIfNotExist(createDatabaseIfNotExist)
             .autodetectExtensions(autodetectExtensions);
 
         if (serverZoneId != null) {

--- a/src/test/java/io/asyncer/r2dbc/mysql/JacksonPrepareIntegrationTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/JacksonPrepareIntegrationTest.java
@@ -22,7 +22,7 @@ package io.asyncer.r2dbc.mysql;
 class JacksonPrepareIntegrationTest extends JacksonIntegrationTestSupport {
 
     JacksonPrepareIntegrationTest() {
-        super(configuration(true, null, sql -> false));
+        super(configuration("r2dbc", false, true, null, sql -> false));
     }
 }
 

--- a/src/test/java/io/asyncer/r2dbc/mysql/JacksonTextIntegrationTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/JacksonTextIntegrationTest.java
@@ -22,6 +22,6 @@ package io.asyncer.r2dbc.mysql;
 class JacksonTextIntegrationTest extends JacksonIntegrationTestSupport {
 
     JacksonTextIntegrationTest() {
-        super(configuration(true, null, null));
+        super(configuration("r2dbc", false, true, null, null));
     }
 }

--- a/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfigurationTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfigurationTest.java
@@ -230,6 +230,7 @@ class MySqlConnectionConfigurationTest {
             .port(3306)
             .password("database-password-in-here")
             .database("r2dbc")
+            .createDatabaseIfNotExist(true)
             .tcpKeepAlive(true)
             .tcpNoDelay(true)
             .connectTimeout(Duration.ofSeconds(3))

--- a/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProviderTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProviderTest.java
@@ -277,6 +277,7 @@ class MySqlConnectionFactoryProviderTest {
             .option(SSL, true)
             .option(Option.valueOf(CONNECT_TIMEOUT.name()), Duration.ofSeconds(3).toString())
             .option(DATABASE, "r2dbc")
+            .option(Option.valueOf("createDatabaseIfNotExist"), true)
             .option(Option.valueOf("serverZoneId"), "Asia/Tokyo")
             .option(Option.valueOf("useServerPrepareStatement"), AllTruePredicate.class.getName())
             .option(Option.valueOf("zeroDate"), "use_round")
@@ -299,6 +300,7 @@ class MySqlConnectionFactoryProviderTest {
         assertThat(configuration.getPassword()).isEqualTo("123456");
         assertThat(configuration.getConnectTimeout()).isEqualTo(Duration.ofSeconds(3));
         assertThat(configuration.getDatabase()).isEqualTo("r2dbc");
+        assertThat(configuration.isCreateDatabaseIfNotExist()).isTrue();
         assertThat(configuration.getZeroDateOption()).isEqualTo(ZeroDateOption.USE_ROUND);
         assertThat(configuration.isTcpKeepAlive()).isTrue();
         assertThat(configuration.isTcpNoDelay()).isTrue();

--- a/src/test/java/io/asyncer/r2dbc/mysql/MySqlPrepareTestKit.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/MySqlPrepareTestKit.java
@@ -22,7 +22,7 @@ package io.asyncer.r2dbc.mysql;
 class MySqlPrepareTestKit extends MySqlTestKitSupport {
 
     MySqlPrepareTestKit() {
-        super(IntegrationTestSupport.configuration(false, null, sql -> true));
+        super(IntegrationTestSupport.configuration("r2dbc", false, false, null, sql -> true));
     }
 
     @Override

--- a/src/test/java/io/asyncer/r2dbc/mysql/MySqlTextTestKit.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/MySqlTextTestKit.java
@@ -22,6 +22,6 @@ package io.asyncer.r2dbc.mysql;
 class MySqlTextTestKit extends MySqlTestKitSupport {
 
     MySqlTextTestKit() {
-        super(IntegrationTestSupport.configuration(false, null, null));
+        super(IntegrationTestSupport.configuration("r2dbc", false, false, null, null));
     }
 }

--- a/src/test/java/io/asyncer/r2dbc/mysql/PrepareQueryIntegrationTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/PrepareQueryIntegrationTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class PrepareQueryIntegrationTest extends QueryIntegrationTestSupport {
 
     PrepareQueryIntegrationTest() {
-        super(configuration(false, null, sql -> true));
+        super(configuration("r2dbc", false, false, null, sql -> true));
     }
 
     @Test

--- a/src/test/java/io/asyncer/r2dbc/mysql/TextQueryIntegrationTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/TextQueryIntegrationTest.java
@@ -22,6 +22,6 @@ package io.asyncer.r2dbc.mysql;
 class TextQueryIntegrationTest extends QueryIntegrationTestSupport {
 
     TextQueryIntegrationTest() {
-        super(configuration(false, null, null));
+        super(configuration("r2dbc", false, false, null, null));
     }
 }

--- a/src/test/java/io/asyncer/r2dbc/mysql/TimeZoneIntegrationTestSupport.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/TimeZoneIntegrationTestSupport.java
@@ -66,7 +66,7 @@ abstract class TimeZoneIntegrationTestSupport extends IntegrationTestSupport {
     }
 
     TimeZoneIntegrationTestSupport(@Nullable Predicate<String> preferPrepared) {
-        super(configuration(false, SERVER_ZONE, preferPrepared));
+        super(configuration("r2dbc", false, false, SERVER_ZONE, preferPrepared));
     }
 
     @Test


### PR DESCRIPTION
Motivation:

See also #158 .

It should be named `createDatabaseIfNotExist`, the same as JDBC naming.

Modification:

- [x] Add option to enable `createDatabaseIfNotExist`
- [x] Support `COM_INIT_DB` and database can be initialized after handshake
- [x] Support sending `CREATE DATABASE IF NOT EXISTS` statement and retrying `COM_INIT_DB` after `COM_INIT_DB` fails for the first time

Result:

Support `createDatabaseIfNotExist`.