### PR TITLE
Upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,19 +66,19 @@
 
     <r2dbc-spi.version>1.0.0.RELEASE</r2dbc-spi.version>
     <reactor.version>2022.0.9</reactor.version>
-    <assertj.version>3.21.0</assertj.version>
-    <jmh.version>1.36</jmh.version>
-    <junit.version>5.9.2</junit.version>
-    <logback.version>1.3.6</logback.version>
-    <mockito.version>4.0.0</mockito.version>
-    <mysql.version>8.0.32</mysql.version>
-    <testcontainers.version>1.17.6</testcontainers.version>
+    <assertj.version>3.24.2</assertj.version>
+    <jmh.version>1.37</jmh.version>
+    <junit.version>5.10.1</junit.version>
+    <logback.version>1.4.14</logback.version>
+    <mockito.version>4.11.0</mockito.version>
+    <mysql.version>8.2.0</mysql.version>
+    <testcontainers.version>1.19.3</testcontainers.version>
     <hikari-cp.version>4.0.3</hikari-cp.version>
-    <spring-framework.version>5.3.25</spring-framework.version>
-    <jackson.version>2.14.2</jackson.version>
+    <spring-framework.version>5.3.31</spring-framework.version>
+    <jackson.version>2.16.0</jackson.version>
     <mbr.version>0.3.0.RELEASE</mbr.version>
     <jsr305.version>3.0.2</jsr305.version>
-    <java-annotations.version>24.0.1</java-annotations.version>
+    <java-annotations.version>24.1.0</java-annotations.version>
   </properties>
 
   <dependencyManagement>
@@ -186,8 +186,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
       <version>${mysql.version}</version>
       <scope>test</scope>
     </dependency>
@@ -242,7 +242,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
           <compilerArgs>
             <arg>-Xlint:all</arg>
@@ -271,12 +271,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.3</version>
         <configuration>
           <excludePackageNames>
             io.asyncer.r2dbc.mysql.authentication,io.asyncer.r2dbc.mysql.client,io.asyncer.r2dbc.mysql.util,io.asyncer.r2dbc.mysql.codec.lob,io.asyncer.r2dbc.mysql.message
@@ -300,7 +300,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -313,7 +313,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.2.3</version>
         <configuration>
           <runOrder>random</runOrder>
           <includes>
@@ -329,7 +329,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.2.3</version>
         <executions>
           <execution>
             <goals>
@@ -389,7 +389,7 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
-            <version>3.3.0</version>
+            <version>3.5.0</version>
             <executions>
               <execution>
                 <id>add-source</id>
@@ -422,7 +422,7 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
-            <version>3.1.0</version>
+            <version>3.1.1</version>
             <executions>
               <execution>
                 <id>run-benchmarks</id>


### PR DESCRIPTION
Motivation:

Upgrade outdated dependencies.

It also solve a security warning for `logback-classic`.

Modification:

`pom.xml`

Result:

All dependencies will be upgraded except Reactor and dependencies that do not support Java 8. The Reactor should be upgraded carefully.