### PR TITLE
Add integration tests for MariaDB

### DIFF
--- a/.github/workflows/ci-mariadb-intergration-tests.yml
+++ b/.github/workflows/ci-mariadb-intergration-tests.yml
@@ -1,0 +1,37 @@
+name: Integration Tests for MariaDB
+
+on:
+  pull_request:
+    branches: [ "trunk", "0.9.x" ]
+
+jobs:
+  mariadb-integration-tests-pr:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        mariadb-version: [ 10.6, 10.11 ]
+    name: Integration test with MariaDB ${{ matrix.mariadb-version }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Temurin 8
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 8
+          cache: maven
+      - name: Shutdown the Default MySQL
+        run: sudo service mysql stop
+      - name: Set up MariaDB ${{ matrix.mariadb-version }}
+        env:
+          MYSQL_DATABASE: r2dbc
+          MYSQL_ROOT_PASSWORD: r2dbc-password!@
+          MARIADB_VERSION: ${{ matrix.mariadb-version }}
+        run: docker-compose -f ${{ github.workspace }}/containers/mariadb-compose.yml up -d
+      - name: Integration test with MySQL ${{ matrix.mysql-version }}
+        run: |
+          ./mvnw -B verify -Dmaven.javadoc.skip=true \
+          -Dmaven.surefire.skip=true \
+          -Dtest.mysql.password=r2dbc-password!@ \
+          -Dtest.mysql.version=${{ matrix.mariadb-version }} \
+          -Dtest.db.type=mariadb \
+          -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        java-version: [ 8, 11, 17 , 21]
+        java-version: [ 8, 11, 17, 21 ]
     name: linux-java-${{ matrix.java-version }}
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ This project is currently being maintained by [@jchrys](https://github.com/jchry
 ![MySQL 8.0 status](https://img.shields.io/badge/MySQL%208.0-pass-blue)
 ![MySQL 8.1 status](https://img.shields.io/badge/MySQL%208.1-pass-blue)
 ![MySQL 8.2 status](https://img.shields.io/badge/MySQL%208.2-pass-blue)
-
+![MariaDB 10.6 status](https://img.shields.io/badge/MariaDB%2010.6-pass-blue)
+![MariaDB 10.11 status](https://img.shields.io/badge/MariaDB%2010.11-pass-blue)
 
 
 In fact, it supports lower versions, in the theory, such as 4.1, 4.0, etc.
@@ -546,7 +547,9 @@ If you want to raise an issue, please follow the recommendations below:
 - The MySQL server does not **actively** return time zone when query `DATETIME` or `TIMESTAMP`, this driver does not attempt time zone conversion. That means should always use `LocalDateTime` for SQL type `DATETIME` or `TIMESTAMP`. Execute `SHOW VARIABLES LIKE '%time_zone%'` to get more information.
 - Should not turn-on the `trace` log level unless debugging. Otherwise, the security information may be exposed through `ByteBuf` dump.
 - If `Statement` bound `returnGeneratedValues`, the `Result` of the `Statement` can be called both: `getRowsUpdated` to get affected rows, and `map` to get last inserted ID.
-- The MySQL may be not support search rows by a binary field, like `BIT`, `BLOB` and `JSON`, because those data fields maybe just an address of reference in MySQL server, or maybe need strict bit-aligned. (but `VARBINARY` is OK)
+- The MySQL may be not support well for searching rows by a binary field, like `BIT` and `JSON`
+  - `BIT`: cannot select 'BIT(64)' with value greater than 'Long.MAX_VALUE' (or equivalent in binary)
+  - `JSON`: different MySQL may have different serialization formats, e.g. MariaDB and MySQL
 
 ## License
 

--- a/containers/mariadb-compose.yml
+++ b/containers/mariadb-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+
+services:
+  mariadb:
+    image: mariadb:${MARIADB_VERSION}
+    container_name: mariadb_${MARIADB_VERSION}
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    ports:
+      - "3306:3306"

--- a/src/main/java/io/asyncer/r2dbc/mysql/ParameterWriter.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/ParameterWriter.java
@@ -48,13 +48,23 @@ public abstract class ParameterWriter extends Writer {
 
     /**
      * Writes a value of {@code long} to current parameter. If current mode is string mode, it will write as a
-     * string like {@code write(String.valueOf(value))}. If it write as a numeric, nothing else can be written
-     * before or after this.
+     * string like {@code write(String.valueOf(value))}. If it writes as a numeric, nothing else can be
+     * written before or after this.
      *
      * @param value the value of {@code long}.
      * @throws IllegalStateException if parameters filled, or something was written before that numeric.
      */
     public abstract void writeLong(long value);
+
+    /**
+     * Writes a value as an unsigned {@code long} to current parameter. If current mode is string mode, it
+     * will write as a string like {@code write(String.valueOf(value))}. If it writes as a numeric, nothing
+     * else can be written before or after this.
+     *
+     * @param value the value as an unsigned {@code long}.
+     * @throws IllegalStateException if parameters filled, or something was written before that numeric.
+     */
+    public abstract void writeUnsignedLong(long value);
 
     /**
      * Writes a value of {@link BigInteger} to current parameter. If current mode is string mode, it will

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/BitSetCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/BitSetCodec.java
@@ -73,7 +73,9 @@ final class BitSetCodec extends AbstractClassedCodec<BitSet> {
 
         MySqlType type;
 
-        if ((byte) bits == bits) {
+        if (bits < 0) {
+            type = MySqlType.BIGINT;
+        } else if ((byte) bits == bits) {
             type = MySqlType.TINYINT;
         } else if ((short) bits == bits) {
             type = MySqlType.SMALLINT;
@@ -135,17 +137,7 @@ final class BitSetCodec extends AbstractClassedCodec<BitSet> {
 
         @Override
         public Mono<Void> publishText(ParameterWriter writer) {
-            return Mono.fromRunnable(() -> {
-                if (value == 0) {
-                    // Must filled by 0 for MySQL 5.5.x, because MySQL 5.5.x does not clear its buffer on type
-                    // BIT (i.e. unsafe allocate).
-                    // So if we do not fill the buffer, it will use last content which is an undefined
-                    // behavior. A classic bug, right?
-                    writer.writeBinary(false);
-                } else {
-                    writer.writeHex(value);
-                }
-            });
+            return Mono.fromRunnable(() -> writer.writeUnsignedLong(value));
         }
 
         @Override

--- a/src/main/java/io/asyncer/r2dbc/mysql/message/client/ParamWriter.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/message/client/ParamWriter.java
@@ -80,6 +80,13 @@ final class ParamWriter extends ParameterWriter {
     }
 
     @Override
+    public void writeUnsignedLong(long value) {
+        startAvailable(Mode.NUMERIC);
+
+        builder.append(Long.toUnsignedString(value));
+    }
+
+    @Override
     public void writeBigInteger(BigInteger value) {
         requireNonNull(value, "value must not be null");
 

--- a/src/test/java/io/asyncer/r2dbc/mysql/IntegrationTestSupport.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/IntegrationTestSupport.java
@@ -102,4 +102,38 @@ abstract class IntegrationTestSupport {
 
         return builder.build();
     }
+
+    boolean envIsLessThanMySql56() {
+        String version = System.getProperty("test.mysql.version");
+
+        if (version == null || version.isEmpty()) {
+            return true;
+        }
+
+        ServerVersion ver = ServerVersion.parse(version);
+        String type = System.getProperty("test.db.type");
+
+        if ("mariadb".equalsIgnoreCase(type)) {
+            return false;
+        }
+
+        return ver.isLessThan(ServerVersion.create(5, 6, 0));
+    }
+
+    boolean envIsLessThanMySql57OrMariaDb102() {
+        String version = System.getProperty("test.mysql.version");
+
+        if (version == null || version.isEmpty()) {
+            return true;
+        }
+
+        ServerVersion ver = ServerVersion.parse(version);
+        String type = System.getProperty("test.db.type");
+
+        if ("mariadb".equalsIgnoreCase(type)) {
+            return ver.isLessThan(ServerVersion.create(10, 2, 0));
+        }
+
+        return ver.isLessThan(ServerVersion.create(5, 7, 0));
+    }
 }

--- a/src/test/java/io/asyncer/r2dbc/mysql/JacksonIntegrationTestSupport.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/JacksonIntegrationTestSupport.java
@@ -22,7 +22,7 @@ import io.asyncer.r2dbc.mysql.json.JacksonCodecRegistrar;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.condition.DisabledIf;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -64,7 +64,7 @@ abstract class JacksonIntegrationTestSupport extends IntegrationTestSupport {
         JacksonCodecRegistrar.tearDown();
     }
 
-    @DisabledIfSystemProperty(named = "test.mysql.version", matches = "5\\.[56](\\.\\d+)?")
+    @DisabledIf("envIsLessThanMySql57OrMariaDb102")
     @Test
     void json() {
         create().flatMap(connection -> Mono.from(connection.createStatement(TDL).execute())

--- a/src/test/java/io/asyncer/r2dbc/mysql/codec/BitSetCodecTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/codec/BitSetCodecTest.java
@@ -53,14 +53,8 @@ class BitSetCodecTest implements CodecTestSupport<BitSet> {
     @Override
     public Object[] stringifyParameters() {
         return Arrays.stream(sets).map(it -> {
-            if (it.isEmpty()) {
-                return "b'0'";
-            } else {
-                byte[] bytes = it.toByteArray();
-                ArrayUtils.reverse(bytes);
-                String content = Hex.toHexString(bytes);
-                return String.format("x'%s'", content.startsWith("0") ? content.substring(1) : content);
-            }
+            long[] array = it.toLongArray();
+            return array.length == 0 ? "0" : Long.toUnsignedString(array[0]);
         }).toArray();
     }
 

--- a/src/test/java/io/asyncer/r2dbc/mysql/json/JacksonCodec.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/json/JacksonCodec.java
@@ -99,7 +99,7 @@ public final class JacksonCodec implements ParametrizedCodec<Object> {
     }
 
     private boolean doCanDecode(MySqlColumnMetadata metadata) {
-        return mode.isDecode() && metadata.getType() == MySqlType.JSON;
+        return mode.isDecode() && (metadata.getType() == MySqlType.JSON || metadata.getType() == MySqlType.TEXT);
     }
 
     private static final class JacksonMySqlParameter implements MySqlParameter {


### PR DESCRIPTION
Motivation:

Add integration tests for MariaDB. See also #178 

Modification:

- Add workflows
- Correct `BitSetCodec` in client-preparing (MariaDB cannot select `BIT` by HEX string)
- Correct JSON test cases for MariaDB
- Add `TEXT` integration test to avoid potential bugs due to differences between MySQL and MariaDB
- Correct README about `BIT` and `TEXT`

Result:

MariaDB integration.