### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Refer to the table below to determine the appropriate version of r2dbc-mysql for
 
 | spring-boot-starter-data-r2dbc | spring-data-r2dbc | r2dbc-spi     | r2dbc-mysql(recommended)     |
 |--------------------------------|-------------------|---------------|------------------------------|
-| 3.0.* and above                | 3.0.* and above   | 1.0.0.RELEASE | io.asyncer:r2dbc-mysql:1.0.4 |
-| 2.7.*                          | 1.5.*             | 0.9.1.RELEASE | io.asyncer:r2dbc-mysql:0.9.5 |
+| 3.0.* and above                | 3.0.* and above   | 1.0.0.RELEASE | io.asyncer:r2dbc-mysql:1.0.6 |
+| 2.7.*                          | 1.5.*             | 0.9.1.RELEASE | io.asyncer:r2dbc-mysql:0.9.7 |
 | 2.6.* and below                | 1.4.* and below   | 0.8.6.RELEASE | dev.miku:r2dbc-mysql:0.8.2   |
 
 ## Supported Features
@@ -58,7 +58,7 @@ However, Docker-certified images do not have these versions lower than 5.5.0, so
 <dependency>
   <groupId>io.asyncer</groupId>
   <artifactId>r2dbc-mysql</artifactId>
-  <version>1.0.4</version>
+  <version>1.0.6</version>
 </dependency>
 ```
 
@@ -68,7 +68,7 @@ However, Docker-certified images do not have these versions lower than 5.5.0, so
 
 ```groovy
 dependencies {
-    implementation 'io.asyncer:r2dbc-mysql:1.0.4'
+    implementation 'io.asyncer:r2dbc-mysql:1.0.6'
 }
 ```
 
@@ -77,7 +77,7 @@ dependencies {
 ```kotlin
 dependencies {
     // Maybe should to use `compile` instead of `implementation` on the lower version of Gradle.
-    implementation("io.asyncer:r2dbc-mysql:1.0.4")
+    implementation("io.asyncer:r2dbc-mysql:1.0.6")
 }
 ```
 


### PR DESCRIPTION
Motivation:
Released 1.0.6 & 0.9.7

Modifications:
Released 1.0.6 & 0.9.7

Result:
up-to-date