### PR TITLE
Add quote identifier support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlStatementSupport.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlStatementSupport.java
@@ -16,12 +16,11 @@
 
 package io.asyncer.r2dbc.mysql;
 
-
 import org.jetbrains.annotations.Nullable;
 
 import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.require;
+import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.requireNonEmpty;
 import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.requireNonNull;
-import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.requireValidName;
 
 /**
  * Base class considers generic logic for {@link MySqlStatement} implementations.
@@ -42,8 +41,8 @@ abstract class MySqlStatementSupport implements MySqlStatement {
                 this.generatedKeyName = LAST_INSERT_ID;
                 return this;
             case 1:
-                this.generatedKeyName = requireValidName(columns[0],
-                    "id name must not be empty and not contain backticks");
+                requireNonEmpty(columns[0], "id name must not be empty");
+                this.generatedKeyName = columns[0];
                 return this;
         }
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/QueryFlow.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/QueryFlow.java
@@ -23,6 +23,7 @@ import io.asyncer.r2dbc.mysql.client.FluxExchangeable;
 import io.asyncer.r2dbc.mysql.constant.ServerStatuses;
 import io.asyncer.r2dbc.mysql.constant.SslMode;
 import io.asyncer.r2dbc.mysql.internal.util.InternalArrays;
+import io.asyncer.r2dbc.mysql.internal.util.StringUtils;
 import io.asyncer.r2dbc.mysql.message.client.AuthResponse;
 import io.asyncer.r2dbc.mysql.message.client.ClientMessage;
 import io.asyncer.r2dbc.mysql.message.client.HandshakeResponse;
@@ -1230,7 +1231,7 @@ final class CreateSavepointState extends AbstractTransactionState {
             statements.add("BEGIN");
         }
 
-        final String doneSql = String.format("SAVEPOINT `%s`", name);
+        final String doneSql = "SAVEPOINT " + StringUtils.quoteIdentifier(name);
         tasks |= CREATE_SAVEPOINT;
         statements.add(doneSql);
         return false;

--- a/src/main/java/io/asyncer/r2dbc/mysql/internal/util/AssertUtils.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/internal/util/AssertUtils.java
@@ -16,7 +16,6 @@
 
 package io.asyncer.r2dbc.mysql.internal.util;
 
-
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -57,20 +56,17 @@ public final class AssertUtils {
     }
 
     /**
-     * Checks that a specified {@link String} is not {@code null} or empty or backticks included and throws a
-     * customized {@link IllegalArgumentException} if it is.
+     * Checks that a {@link String} is neither {@code null} nor empty, and throws a customized
+     * {@link IllegalArgumentException} if it is.
      *
-     * @param name    the {@link String} to check for nullity or empty or backticks included.
+     * @param s       the string to check for empty.
      * @param message the detail message to be used by thrown {@link IllegalArgumentException}.
-     * @return {@code name} if not {@code null} or empty or backticks included.
-     * @throws IllegalArgumentException if {@code name} is {@code null} or empty or backticks included.
+     * @throws IllegalArgumentException if {@code s} is {@code null} or empty.
      */
-    public static String requireValidName(@Nullable String name, String message) {
-        if (name == null || name.isEmpty() || name.indexOf('`') >= 0) {
+    public static void requireNonEmpty(@Nullable String s, String message) {
+        if (s == null || s.isEmpty()) {
             throw new IllegalArgumentException(message);
         }
-
-        return name;
     }
 
     private AssertUtils() { }

--- a/src/main/java/io/asyncer/r2dbc/mysql/internal/util/StringUtils.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/internal/util/StringUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql.internal.util;
+
+import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.requireNonEmpty;
+
+/**
+ * A utility for processing {@link String} in MySQL/MariaDB.
+ */
+public final class StringUtils {
+
+    private static final char QUOTE = '`';
+
+    public static String quoteIdentifier(String identifier) {
+        requireNonEmpty(identifier, "identifier must not be empty");
+
+        int index = identifier.indexOf(QUOTE);
+
+        if (index == -1) {
+            return QUOTE + identifier + QUOTE;
+        }
+
+        int len = identifier.length();
+        StringBuilder builder = new StringBuilder(len + 10).append(QUOTE);
+        int fromIndex = 0;
+
+        while (index != -1) {
+            builder.append(identifier, fromIndex, index)
+                .append(QUOTE)
+                .append(QUOTE);
+            fromIndex = index + 1;
+            index = identifier.indexOf(QUOTE, fromIndex);
+        }
+
+        if (fromIndex < len) {
+            builder.append(identifier, fromIndex, len);
+        }
+
+        return builder.append(QUOTE).toString();
+    }
+
+    private StringUtils() {
+    }
+}

--- a/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionTest.java
@@ -98,9 +98,6 @@ class MySqlConnectionTest {
         ThrowableTypeAssert<?> asserted = assertThatIllegalArgumentException();
 
         asserted.isThrownBy(() -> noPrepare.createSavepoint(""));
-        asserted.isThrownBy(() -> noPrepare.createSavepoint("`"));
-        asserted.isThrownBy(() -> noPrepare.createSavepoint("name`"));
-        asserted.isThrownBy(() -> noPrepare.createSavepoint("nam`e"));
         asserted.isThrownBy(() -> noPrepare.createSavepoint(null));
     }
 
@@ -110,9 +107,6 @@ class MySqlConnectionTest {
         ThrowableTypeAssert<?> asserted = assertThatIllegalArgumentException();
 
         asserted.isThrownBy(() -> noPrepare.releaseSavepoint(""));
-        asserted.isThrownBy(() -> noPrepare.releaseSavepoint("`"));
-        asserted.isThrownBy(() -> noPrepare.releaseSavepoint("name`"));
-        asserted.isThrownBy(() -> noPrepare.releaseSavepoint("nam`e"));
         asserted.isThrownBy(() -> noPrepare.releaseSavepoint(null));
     }
 
@@ -122,9 +116,6 @@ class MySqlConnectionTest {
         ThrowableTypeAssert<?> asserted = assertThatIllegalArgumentException();
 
         asserted.isThrownBy(() -> noPrepare.rollbackTransactionToSavepoint(""));
-        asserted.isThrownBy(() -> noPrepare.rollbackTransactionToSavepoint("`"));
-        asserted.isThrownBy(() -> noPrepare.rollbackTransactionToSavepoint("name`"));
-        asserted.isThrownBy(() -> noPrepare.rollbackTransactionToSavepoint("nam`e"));
         asserted.isThrownBy(() -> noPrepare.rollbackTransactionToSavepoint(null));
     }
 

--- a/src/test/java/io/asyncer/r2dbc/mysql/StatementTestSupport.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/StatementTestSupport.java
@@ -156,6 +156,8 @@ interface StatementTestSupport<T extends MySqlStatementSupport> {
         assertEquals(statement.generatedKeyName, "LAST_INSERT_ID");
         statement.returnGeneratedValues("generated");
         assertEquals(statement.generatedKeyName, "generated");
+        statement.returnGeneratedValues("generate`d");
+        assertEquals(statement.generatedKeyName, "generate`d");
     }
 
     @SuppressWarnings("ConstantConditions")
@@ -166,8 +168,6 @@ interface StatementTestSupport<T extends MySqlStatementSupport> {
         assertThrows(IllegalArgumentException.class, () -> statement.returnGeneratedValues((String) null));
         assertThrows(IllegalArgumentException.class, () -> statement.returnGeneratedValues((String[]) null));
         assertThrows(IllegalArgumentException.class, () -> statement.returnGeneratedValues(""));
-        assertThrows(IllegalArgumentException.class, () -> statement.returnGeneratedValues("`generating`"));
-        assertThrows(IllegalArgumentException.class, () -> statement.returnGeneratedValues("generating`"));
         assertThrows(IllegalArgumentException.class, () ->
             statement.returnGeneratedValues("generated", "names"));
     }

--- a/src/test/java/io/asyncer/r2dbc/mysql/internal/util/StringUtilsTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/internal/util/StringUtilsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql.internal.util;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * Unit tests for {@link StringUtils}.
+ */
+class StringUtilsTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        " ",
+        "`",
+        "``",
+        "bad`",
+        "`name",
+        "bad`name",
+        "`bad`name`",
+        "μ's",
+        " Reading books can be a \"great way\" to help you achieve more 'success' in `life` ",
+        "b%!@#()ar`\nfr-=321d`na``me",
+        "`b%!@#()ar`\nfr-=321d`na``me",
+        "`b%!@#()ar`\nfr-=321d`na``me``",
+    })
+    void quoteIdentifier(String name) {
+        assertThat(StringUtils.quoteIdentifier(name)).isEqualTo('`' + name.replaceAll("`", "``") + '`');
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void badQuoteIdentifier(String name) {
+        assertThatIllegalArgumentException().isThrownBy(() -> StringUtils.quoteIdentifier(name));
+    }
+}


### PR DESCRIPTION
Motivation:

Support backticks in savepoint/database/table/column names.

See also #198 .

Modification:

Add `StringUtils#quoteIdentifier` and `AssertUtils#requireNonEmpty` for all identifier names.

Add dependency `junit-jupiter-params` to simplify test cases.

Remove `AssertUtils#requireValidName`.

Result:

User can use backticks in identifier name.
