### PR TITLE
Add `RETURNING` support for MariaDB 10.5.1+

### DIFF
--- a/src/main/java/io/asyncer/r2dbc/mysql/Binding.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/Binding.java
@@ -70,8 +70,8 @@ final class Binding {
         return new PreparedExecuteMessage(statementId, immediate, drainValues());
     }
 
-    PreparedTextQueryMessage toTextMessage(Query query) {
-        return new PreparedTextQueryMessage(query, drainValues());
+    PreparedTextQueryMessage toTextMessage(Query query, String returning) {
+        return new PreparedTextQueryMessage(query, returning, drainValues());
     }
 
     /**

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlStatementSupport.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlStatementSupport.java
@@ -49,7 +49,7 @@ abstract class MySqlStatementSupport implements MySqlStatement {
 
         if (len == 0) {
             this.generatedColumns = InternalArrays.EMPTY_STRINGS;
-        } else if (len == 1 || supportReturning()) {
+        } else if (len == 1 || supportReturning(context)) {
             String[] result = new String[len];
 
             for (int i = 0; i < len; ++i) {
@@ -60,7 +60,7 @@ abstract class MySqlStatementSupport implements MySqlStatement {
             this.generatedColumns = result;
         } else {
             String db = context.isMariaDb() ? "MariaDB 10.5.0 or below" : "MySQL";
-            throw new IllegalArgumentException(db + " supports only LAST_INSERT_ID instead of RETURNING");
+            throw new IllegalArgumentException(db + " can have only one column");
         }
 
         return this;
@@ -77,7 +77,7 @@ abstract class MySqlStatementSupport implements MySqlStatement {
         String[] columns = this.generatedColumns;
 
         // MariaDB should use `RETURNING` clause instead.
-        if (columns == null || supportReturning()) {
+        if (columns == null || supportReturning(this.context)) {
             return null;
         }
 
@@ -91,7 +91,7 @@ abstract class MySqlStatementSupport implements MySqlStatement {
     final String returningIdentifiers() {
         String[] columns = this.generatedColumns;
 
-        if (columns == null || !supportReturning()) {
+        if (columns == null || !supportReturning(context)) {
             return "";
         }
 
@@ -105,7 +105,7 @@ abstract class MySqlStatementSupport implements MySqlStatement {
         return String.join(",", columns);
     }
 
-    private boolean supportReturning() {
+    static boolean supportReturning(ConnectionContext context) {
         return context.isMariaDb() && context.getServerVersion().isGreaterThanOrEqualTo(MARIA_10_5_1);
     }
 }

--- a/src/main/java/io/asyncer/r2dbc/mysql/ParametrizedStatementSupport.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/ParametrizedStatementSupport.java
@@ -45,19 +45,18 @@ abstract class ParametrizedStatementSupport extends MySqlStatementSupport {
 
     protected final Query query;
 
-    protected final ConnectionContext context;
-
     private final Bindings bindings;
 
     private final AtomicBoolean executed = new AtomicBoolean();
 
     ParametrizedStatementSupport(Client client, Codecs codecs, Query query, ConnectionContext context) {
+        super(context);
+
         requireNonNull(query, "query must not be null");
         require(query.getParameters() > 0, "parameters must be a positive integer");
 
         this.client = requireNonNull(client, "client must not be null");
         this.codecs = requireNonNull(codecs, "codecs must not be null");
-        this.context = requireNonNull(context, "context must not be null");
         this.query = query;
         this.bindings = new Bindings(query.getParameters());
     }

--- a/src/main/java/io/asyncer/r2dbc/mysql/PrepareSimpleStatement.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/PrepareSimpleStatement.java
@@ -19,6 +19,7 @@ package io.asyncer.r2dbc.mysql;
 import io.asyncer.r2dbc.mysql.cache.PrepareCache;
 import io.asyncer.r2dbc.mysql.client.Client;
 import io.asyncer.r2dbc.mysql.codec.Codecs;
+import io.asyncer.r2dbc.mysql.internal.util.StringUtils;
 import reactor.core.publisher.Flux;
 
 import java.util.Collections;
@@ -45,8 +46,9 @@ final class PrepareSimpleStatement extends SimpleStatementSupport {
 
     @Override
     public Flux<MySqlResult> execute() {
-        return QueryFlow.execute(client, sql, BINDINGS, fetchSize, prepareCache)
-            .map(messages -> MySqlResult.toResult(true, codecs, context, generatedKeyName, messages));
+        return Flux.defer(() -> QueryFlow.execute(client,
+                StringUtils.extendReturning(sql, returningIdentifiers()), BINDINGS, fetchSize, prepareCache))
+            .map(messages -> MySqlResult.toResult(true, codecs, context, syntheticKeyName(), messages));
     }
 
     @Override

--- a/src/main/java/io/asyncer/r2dbc/mysql/QueryLogger.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/QueryLogger.java
@@ -17,6 +17,7 @@
 package io.asyncer.r2dbc.mysql;
 
 
+import io.asyncer.r2dbc.mysql.internal.util.StringUtils;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
@@ -31,9 +32,10 @@ final class QueryLogger {
         logger.debug("Executing direct query: {}", query);
     }
 
-    static void log(Query query) {
+    static void log(Query query, String returning) {
         if (logger.isDebugEnabled()) {
-            logger.debug("Executing format query: {}", query.getFormattedSql());
+            logger.debug("Executing format query: {}",
+                StringUtils.extendReturning(query.getFormattedSql(), returning));
         }
     }
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/SimpleStatementSupport.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/SimpleStatementSupport.java
@@ -30,14 +30,13 @@ abstract class SimpleStatementSupport extends MySqlStatementSupport {
 
     protected final Codecs codecs;
 
-    protected final ConnectionContext context;
-
     protected final String sql;
 
     SimpleStatementSupport(Client client, Codecs codecs, ConnectionContext context, String sql) {
+        super(context);
+
         this.client = requireNonNull(client, "client must not be null");
         this.codecs = requireNonNull(codecs, "codecs must not be null");
-        this.context = requireNonNull(context, "context must not be null");
         this.sql = requireNonNull(sql, "sql must not be null");
     }
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/TextParametrizedStatement.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/TextParametrizedStatement.java
@@ -33,7 +33,7 @@ final class TextParametrizedStatement extends ParametrizedStatementSupport {
 
     @Override
     protected Flux<MySqlResult> execute(List<Binding> bindings) {
-        return QueryFlow.execute(client, query, bindings)
-            .map(messages -> MySqlResult.toResult(false, codecs, context, generatedKeyName, messages));
+        return Flux.defer(() -> QueryFlow.execute(client, query, returningIdentifiers(), bindings))
+            .map(messages -> MySqlResult.toResult(false, codecs, context, syntheticKeyName(), messages));
     }
 }

--- a/src/main/java/io/asyncer/r2dbc/mysql/TextSimpleStatement.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/TextSimpleStatement.java
@@ -18,6 +18,7 @@ package io.asyncer.r2dbc.mysql;
 
 import io.asyncer.r2dbc.mysql.client.Client;
 import io.asyncer.r2dbc.mysql.codec.Codecs;
+import io.asyncer.r2dbc.mysql.internal.util.StringUtils;
 import reactor.core.publisher.Flux;
 
 /**
@@ -31,7 +32,9 @@ final class TextSimpleStatement extends SimpleStatementSupport {
 
     @Override
     public Flux<MySqlResult> execute() {
-        return QueryFlow.execute(client, sql)
-            .map(messages -> MySqlResult.toResult(false, codecs, context, generatedKeyName, messages));
+        return Flux.defer(() -> QueryFlow.execute(
+            client,
+            StringUtils.extendReturning(sql, returningIdentifiers()))
+        ).map(messages -> MySqlResult.toResult(false, codecs, context, syntheticKeyName(), messages));
     }
 }

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/Codecs.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/Codecs.java
@@ -62,7 +62,7 @@ public interface Codecs {
         CodecContext context);
 
     /**
-     * Decode the last inserted ID from {@code OkMessage} as a specified {@link ParameterizedType type}.
+     * Decode the last inserted ID from {@code OkMessage} as a specified {@link Class type}.
      *
      * @param <T>   the generic result type.
      * @param value the last inserted ID.

--- a/src/main/java/io/asyncer/r2dbc/mysql/internal/util/StringUtils.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/internal/util/StringUtils.java
@@ -25,6 +25,12 @@ public final class StringUtils {
 
     private static final char QUOTE = '`';
 
+    /**
+     * Quotes identifier with backticks, it will escape backticks in the identifier.
+     *
+     * @param identifier the identifier
+     * @return quoted identifier
+     */
     public static String quoteIdentifier(String identifier) {
         requireNonEmpty(identifier, "identifier must not be empty");
 
@@ -51,6 +57,17 @@ public final class StringUtils {
         }
 
         return builder.append(QUOTE).toString();
+    }
+
+    /**
+     * Extends a SQL statement with {@code RETURNING} clause.
+     *
+     * @param sql the original SQL statement.
+     * @param returning quoted column identifiers.
+     * @return the SQL statement with {@code RETURNING} clause.
+     */
+    public static String extendReturning(String sql, String returning) {
+        return returning.isEmpty() ? sql : sql + " RETURNING " + returning;
     }
 
     private StringUtils() {

--- a/src/main/java/io/asyncer/r2dbc/mysql/message/server/ServerMessageDecoder.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/message/server/ServerMessageDecoder.java
@@ -196,7 +196,7 @@ public final class ServerMessageDecoder {
                 return ErrorMessage.decode(buf);
             case OK:
                 if (OkMessage.isValidSize(buf.readableBytes())) {
-                    return OkMessage.decode(buf, context);
+                    return OkMessage.decode(false, buf, context);
                 }
 
                 break;
@@ -209,7 +209,7 @@ public final class ServerMessageDecoder {
                     // so if readable bytes upper than 7, it means if it is column count,
                     // column count is already upper than (1 << 24) - 1 = 16777215, it is impossible.
                     // So it must be OK message, not be column count.
-                    return OkMessage.decode(buf, context);
+                    return OkMessage.decode(false, buf, context);
                 } else if (EofMessage.isValidSize(byteSize)) {
                     return EofMessage.decode(buf);
                 }
@@ -231,7 +231,7 @@ public final class ServerMessageDecoder {
         switch (header) {
             case OK:
                 if (OkMessage.isValidSize(buf.readableBytes())) {
-                    return OkMessage.decode(buf, context);
+                    return OkMessage.decode(false, buf, context);
                 }
 
                 break;
@@ -333,7 +333,7 @@ public final class ServerMessageDecoder {
                 ByteBuf combined = NettyBufferUtils.composite(buffers);
 
                 try {
-                    return OkMessage.decode(combined, context);
+                    return OkMessage.decode(true, combined, context);
                 } finally {
                     combined.release();
                 }

--- a/src/test/java/io/asyncer/r2dbc/mysql/ConnectionContextTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/ConnectionContextTest.java
@@ -68,13 +68,18 @@ public class ConnectionContextTest {
     }
 
     public static ConnectionContext mock() {
-        return mock(ZoneId.systemDefault());
+        return mock(false, ZoneId.systemDefault());
     }
 
-    public static ConnectionContext mock(ZoneId zoneId) {
+    public static ConnectionContext mock(boolean isMariaDB) {
+        return mock(isMariaDB, ZoneId.systemDefault());
+    }
+
+    public static ConnectionContext mock(boolean isMariaDB, ZoneId zoneId) {
         ConnectionContext context = new ConnectionContext(ZeroDateOption.USE_NULL, zoneId);
 
-        context.init(1, ServerVersion.parse("8.0.11.MOCKED"), Capability.of(-1));
+        context.init(1, ServerVersion.parse(isMariaDB ? "11.2.22.MOCKED" : "8.0.11.MOCKED"),
+            Capability.of(~(isMariaDB ? 1 : 0)));
         context.setServerStatuses(ServerStatuses.AUTO_COMMIT);
 
         return context;

--- a/src/test/java/io/asyncer/r2dbc/mysql/IntegrationTestSupport.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/IntegrationTestSupport.java
@@ -136,4 +136,16 @@ abstract class IntegrationTestSupport {
 
         return ver.isLessThan(ServerVersion.create(5, 7, 0));
     }
+
+    static boolean envIsMariaDb10_5_1() {
+        String type = System.getProperty("test.db.type");
+
+        if (!"mariadb".equalsIgnoreCase(type)) {
+            return false;
+        }
+
+        ServerVersion ver = ServerVersion.parse(System.getProperty("test.mysql.version"));
+
+        return ver.isGreaterThanOrEqualTo(ServerVersion.create(10, 5, 1));
+    }
 }

--- a/src/test/java/io/asyncer/r2dbc/mysql/MariaDbIntegrationTestSupport.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/MariaDbIntegrationTestSupport.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2024 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql;
+
+import io.r2dbc.spi.Readable;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import java.time.ZonedDateTime;
+import java.util.function.Predicate;
+
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Base class considers integration tests for MariaDB.
+ */
+abstract class MariaDbIntegrationTestSupport extends IntegrationTestSupport {
+
+    MariaDbIntegrationTestSupport(@Nullable Predicate<String> preferPrepared) {
+        super(configuration("r2dbc", false, false, null, preferPrepared));
+    }
+
+    @Test
+    void returningExpression() {
+        complete(conn -> conn.createStatement("CREATE TEMPORARY TABLE test (" +
+            "id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,value INT NOT NULL)")
+            .execute()
+            .flatMap(IntegrationTestSupport::extractRowsUpdated)
+            .thenMany(conn.createStatement("INSERT INTO test(value) VALUES (?)")
+                .bind(0, 2)
+                .returnGeneratedValues("CURRENT_TIMESTAMP")
+                .execute())
+            .flatMap(result -> result.map(r -> r.get(0, ZonedDateTime.class)))
+            .collectList()
+            .doOnNext(list -> assertThat(list).hasSize(1)
+                .noneMatch(it -> it.isBefore(ZonedDateTime.now().minusSeconds(10)))));
+    }
+
+    @Test
+    void allReturning() {
+        complete(conn -> conn.createStatement("CREATE TEMPORARY TABLE test (" +
+                "id INT NOT NULL AUTO_INCREMENT PRIMARY KEY," +
+                "value INT NOT NULL," +
+                "created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3))")
+            .execute()
+            .flatMap(IntegrationTestSupport::extractRowsUpdated)
+            .thenMany(conn.createStatement("INSERT INTO test(value) VALUES (?),(?),(?),(?),(?)")
+                .bind(0, 2)
+                .bind(1, 4)
+                .bind(2, 6)
+                .bind(3, 8)
+                .bind(4, 10)
+                .returnGeneratedValues()
+                .execute())
+            .flatMap(result -> result.map(DataEntity::read))
+            .collectList()
+            .doOnNext(list -> assertThat(list).hasSize(5)
+                .map(DataEntity::getValue)
+                .containsExactly(2, 4, 6, 8, 10))
+            .doOnNext(list -> assertThat(list.stream().map(DataEntity::getId).distinct()).hasSize(5))
+            .doOnNext(list -> assertThat(list.stream().map(DataEntity::getCreatedAt))
+                .noneMatch(it -> it.isBefore(ZonedDateTime.now().minusSeconds(10))))
+            .thenMany(conn.createStatement("REPLACE test(id, value) VALUES (1,?),(2,?),(3,?),(4,?),(5,?)")
+                .bind(0, 3)
+                .bind(1, 5)
+                .bind(2, 7)
+                .bind(3, 9)
+                .bind(4, 11)
+                .returnGeneratedValues()
+                .execute())
+            .flatMap(result -> result.map(DataEntity::read))
+            .collectList()
+            .doOnNext(list -> assertThat(list).hasSize(5)
+                .map(DataEntity::getValue)
+                .containsExactly(3, 5, 7, 9, 11))
+            .doOnNext(list -> assertThat(list.stream().map(DataEntity::getCreatedAt))
+                .noneMatch(it -> it.isBefore(ZonedDateTime.now().minusSeconds(10)))));
+    }
+
+    @Test
+    void partialReturning() {
+        complete(conn -> conn.createStatement("CREATE TEMPORARY TABLE test (" +
+                "id INT NOT NULL AUTO_INCREMENT PRIMARY KEY," +
+                "value INT NOT NULL," +
+                "created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3))")
+            .execute()
+            .flatMap(IntegrationTestSupport::extractRowsUpdated)
+            .thenMany(conn.createStatement("INSERT INTO test(value) VALUES (?),(?),(?),(?),(?)")
+                .bind(0, 2)
+                .bind(1, 4)
+                .bind(2, 6)
+                .bind(3, 8)
+                .bind(4, 10)
+                .returnGeneratedValues("id", "created_at")
+                .execute())
+            .flatMap(result -> result.map(DataEntity::withoutValue))
+            .collectList()
+            .doOnNext(list -> assertThat(list).hasSize(5)
+                .map(DataEntity::getValue)
+                .containsOnly(0))
+            .doOnNext(list -> assertThat(list.stream().map(DataEntity::getId).distinct()).hasSize(5))
+            .doOnNext(list -> assertThat(list.stream().map(DataEntity::getCreatedAt))
+                .noneMatch(it -> it.isBefore(ZonedDateTime.now().minusSeconds(10))))
+            .thenMany(conn.createStatement("REPLACE test(id, value) VALUES (1,?),(2,?),(3,?),(4,?),(5,?)")
+                .bind(0, 3)
+                .bind(1, 5)
+                .bind(2, 7)
+                .bind(3, 9)
+                .bind(4, 11)
+                .returnGeneratedValues("id", "created_at")
+                .execute())
+            .flatMap(result -> result.map(DataEntity::withoutValue))
+            .collectList()
+            .doOnNext(list -> assertThat(list).hasSize(5)
+                .map(DataEntity::getValue)
+                .containsOnly(0))
+            .doOnNext(list -> assertThat(list.stream().map(DataEntity::getCreatedAt))
+                .noneMatch(it -> it.isBefore(ZonedDateTime.now().minusSeconds(10))))
+        );
+    }
+
+    private static final class DataEntity {
+
+        private final int id;
+
+        private final int value;
+
+        private final ZonedDateTime createdAt;
+
+        private DataEntity(int id, int value, ZonedDateTime createdAt) {
+            this.id = id;
+            this.value = value;
+            this.createdAt = createdAt;
+        }
+
+        int getId() {
+            return id;
+        }
+
+        int getValue() {
+            return value;
+        }
+
+        ZonedDateTime getCreatedAt() {
+            return createdAt;
+        }
+
+        static DataEntity read(Readable readable) {
+            Integer id = readable.get("id", Integer.TYPE);
+            Integer value = readable.get("value", Integer.class);
+            ZonedDateTime createdAt = readable.get("created_at", ZonedDateTime.class);
+
+            requireNonNull(id, "id must not be null");
+            requireNonNull(value, "value must not be null");
+            requireNonNull(createdAt, "createdAt must not be null");
+
+            return new DataEntity(id, value, createdAt);
+        }
+
+        static DataEntity withoutValue(Readable readable) {
+            Integer id = readable.get("id", Integer.TYPE);
+            ZonedDateTime createdAt = readable.get("created_at", ZonedDateTime.class);
+
+            requireNonNull(id, "id must not be null");
+            requireNonNull(createdAt, "createdAt must not be null");
+
+            return new DataEntity(id, 0, createdAt);
+        }
+    }
+}

--- a/src/test/java/io/asyncer/r2dbc/mysql/MariaDbIntegrationTestSupport.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/MariaDbIntegrationTestSupport.java
@@ -134,6 +134,21 @@ abstract class MariaDbIntegrationTestSupport extends IntegrationTestSupport {
         );
     }
 
+    @Test
+    void returningGetRowUpdated() {
+        complete(conn -> conn.createStatement("CREATE TEMPORARY TABLE test(" +
+            "id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,value INT NOT NULL)")
+            .execute()
+            .flatMap(IntegrationTestSupport::extractRowsUpdated)
+            .thenMany(conn.createStatement("INSERT INTO test(value) VALUES (?),(?)")
+                .bind(0, 2)
+                .bind(1, 4)
+                .returnGeneratedValues()
+                .execute())
+            .flatMap(IntegrationTestSupport::extractRowsUpdated)
+            .doOnNext(it -> assertThat(it).isEqualTo(2)));
+    }
+
     private static final class DataEntity {
 
         private final int id;

--- a/src/test/java/io/asyncer/r2dbc/mysql/MariaDbPrepareIntegrationTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/MariaDbPrepareIntegrationTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql;
+
+import org.junit.jupiter.api.condition.EnabledIf;
+
+/**
+ * Integration tests for MariaDB with server-preparing statements.
+ */
+@EnabledIf("envIsMariaDb10_5_1")
+class MariaDbPrepareIntegrationTest extends MariaDbIntegrationTestSupport {
+
+    MariaDbPrepareIntegrationTest() {
+        super(sql -> true);
+    }
+}

--- a/src/test/java/io/asyncer/r2dbc/mysql/MariaDbTextIntegrationTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/MariaDbTextIntegrationTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql;
+
+import org.junit.jupiter.api.condition.EnabledIf;
+
+/**
+ * Integration tests for MariaDB with client-preparing statements.
+ */
+@EnabledIf("envIsMariaDb10_5_1")
+class MariaDbTextIntegrationTest extends MariaDbIntegrationTestSupport {
+
+    MariaDbTextIntegrationTest() {
+        super(null);
+    }
+}

--- a/src/test/java/io/asyncer/r2dbc/mysql/PrepareParametrizedStatementTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/PrepareParametrizedStatementTest.java
@@ -32,8 +32,6 @@ class PrepareParametrizedStatementTest implements StatementTestSupport<PreparePa
 
     private final Client client = mock(Client.class);
 
-    private final ConnectionContext context = ConnectionContextTest.mock();
-
     private final Codecs codecs = Codecs.builder(UnpooledByteBufAllocator.DEFAULT).build();
 
     private final Field fetchSize = PrepareParametrizedStatement.class.getDeclaredField("fetchSize");
@@ -48,9 +46,14 @@ class PrepareParametrizedStatementTest implements StatementTestSupport<PreparePa
     }
 
     @Override
-    public PrepareParametrizedStatement makeInstance(String sql, String ignored) {
-        return new PrepareParametrizedStatement(client, codecs, Query.parse(sql), context,
-            Caches.createPrepareCache(0));
+    public PrepareParametrizedStatement makeInstance(boolean isMariaDB, String sql, String ignored) {
+        return new PrepareParametrizedStatement(
+            client,
+            codecs,
+            Query.parse(sql),
+            ConnectionContextTest.mock(isMariaDB),
+            Caches.createPrepareCache(0)
+        );
     }
 
     @Override

--- a/src/test/java/io/asyncer/r2dbc/mysql/PrepareSimpleStatementTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/PrepareSimpleStatementTest.java
@@ -31,8 +31,6 @@ class PrepareSimpleStatementTest implements StatementTestSupport<PrepareSimpleSt
 
     private final Client client = mock(Client.class);
 
-    private final ConnectionContext context = ConnectionContextTest.mock();
-
     private final Codecs codecs = mock(Codecs.class);
 
     private final Field fetchSize = PrepareSimpleStatement.class.getDeclaredField("fetchSize");
@@ -62,8 +60,14 @@ class PrepareSimpleStatementTest implements StatementTestSupport<PrepareSimpleSt
     }
 
     @Override
-    public PrepareSimpleStatement makeInstance(String ignored, String sql) {
-        return new PrepareSimpleStatement(client, codecs, context, sql, Caches.createPrepareCache(0));
+    public PrepareSimpleStatement makeInstance(boolean isMariaDB, String ignored, String sql) {
+        return new PrepareSimpleStatement(
+            client,
+            codecs,
+            ConnectionContextTest.mock(isMariaDB),
+            sql,
+            Caches.createPrepareCache(0)
+        );
     }
 
     @Override

--- a/src/test/java/io/asyncer/r2dbc/mysql/TextParametrizedStatementTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/TextParametrizedStatementTest.java
@@ -29,8 +29,6 @@ class TextParametrizedStatementTest implements StatementTestSupport<TextParametr
 
     private final Client client = mock(Client.class);
 
-    private final ConnectionContext context = ConnectionContextTest.mock();
-
     private final Codecs codecs = Codecs.builder(UnpooledByteBufAllocator.DEFAULT).build();
 
     @Override
@@ -39,8 +37,13 @@ class TextParametrizedStatementTest implements StatementTestSupport<TextParametr
     }
 
     @Override
-    public TextParametrizedStatement makeInstance(String sql, String ignored) {
-        return new TextParametrizedStatement(client, codecs, Query.parse(sql), context);
+    public TextParametrizedStatement makeInstance(boolean isMariaDB, String sql, String ignored) {
+        return new TextParametrizedStatement(
+            client,
+            codecs,
+            Query.parse(sql),
+            ConnectionContextTest.mock(isMariaDB)
+        );
     }
 
     @Override

--- a/src/test/java/io/asyncer/r2dbc/mysql/TextSimpleStatementTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/TextSimpleStatementTest.java
@@ -28,8 +28,6 @@ class TextSimpleStatementTest implements StatementTestSupport<TextSimpleStatemen
 
     private final Client client = mock(Client.class);
 
-    private final ConnectionContext context = ConnectionContextTest.mock();
-
     private final Codecs codecs = mock(Codecs.class);
 
     @Override
@@ -53,8 +51,8 @@ class TextSimpleStatementTest implements StatementTestSupport<TextSimpleStatemen
     }
 
     @Override
-    public TextSimpleStatement makeInstance(String ignored, String sql) {
-        return new TextSimpleStatement(client, codecs, context, sql);
+    public TextSimpleStatement makeInstance(boolean isMariaDB, String ignored, String sql) {
+        return new TextSimpleStatement(client, codecs, ConnectionContextTest.mock(isMariaDB), sql);
     }
 
     @Override

--- a/src/test/java/io/asyncer/r2dbc/mysql/codec/DateTimeCodecTestSupport.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/codec/DateTimeCodecTestSupport.java
@@ -63,7 +63,7 @@ abstract class DateTimeCodecTestSupport<T extends Temporal> implements CodecTest
 
     @Override
     public CodecContext context() {
-        return ConnectionContextTest.mock(ENCODE_SERVER_ZONE);
+        return ConnectionContextTest.mock(false, ENCODE_SERVER_ZONE);
     }
 
     protected final String toText(Temporal dateTime) {

--- a/src/test/java/io/asyncer/r2dbc/mysql/codec/TimeCodecTestSupport.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/codec/TimeCodecTestSupport.java
@@ -55,7 +55,7 @@ abstract class TimeCodecTestSupport<T extends Temporal> implements CodecTestSupp
 
     @Override
     public CodecContext context() {
-        return ConnectionContextTest.mock(ENCODE_SERVER_ZONE);
+        return ConnectionContextTest.mock(false, ENCODE_SERVER_ZONE);
     }
 
     protected final String toText(Temporal time) {


### PR DESCRIPTION
Motivation:

Add `RETURNING` clause support for MariaDB 10.5.1+ .

See also #177 .

Modification:

Add `RETURNING` clause in `MySqlStatement#returnGeneratedValues` and query message packets.

Result:

For MariaDB 10.5.1 and above, `MySqlStatement#returnGeneratedValues` will use `RETURNING` clause instead of `LAST_INSERT_ID`.

Notice:

For MariaDB 10.5.0 and below, `MySqlStatement#returnGeneratedValues` will still use `LAST_INSERT_ID` due to these versions do not support `RETURNING` clause.