### PR TITLE
Ensure isolation level is applied to subsequent transactions after setting

### DIFF
--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnection.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnection.java
@@ -129,7 +129,7 @@ public final class MySqlConnection implements Connection, Lifecycle, ConnectionS
 
     private final MySqlConnectionMetadata metadata;
 
-    private final IsolationLevel sessionLevel;
+    private volatile IsolationLevel sessionLevel;
 
     private final QueryCache queryCache;
 
@@ -303,13 +303,27 @@ public final class MySqlConnection implements Connection, Lifecycle, ConnectionS
         return currentLevel;
     }
 
+    /**
+     * Gets session transaction isolation level(Only for testing).
+     *
+     * @return session transaction isolation level.
+     */
+    IsolationLevel getSessionTransactionIsolationLevel() {
+        return sessionLevel;
+    }
+
     @Override
     public Mono<Void> setTransactionIsolationLevel(IsolationLevel isolationLevel) {
         requireNonNull(isolationLevel, "isolationLevel must not be null");
 
-        // Set next transaction isolation level.
-        return QueryFlow.executeVoid(client, "SET TRANSACTION ISOLATION LEVEL " + isolationLevel.asSql())
-            .doOnSuccess(ignored -> setIsolationLevel(isolationLevel));
+        // Set subsequent transaction isolation level.
+        return QueryFlow.executeVoid(client, "SET SESSION TRANSACTION ISOLATION LEVEL " + isolationLevel.asSql())
+            .doOnSuccess(ignored -> {
+                this.sessionLevel = isolationLevel;
+                if (!this.isInTransaction()) {
+                    this.currentLevel = isolationLevel;
+                }
+            });
     }
 
     @Override

--- a/src/main/java/io/asyncer/r2dbc/mysql/message/client/TextQueryMessage.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/message/client/TextQueryMessage.java
@@ -19,6 +19,7 @@ package io.asyncer.r2dbc.mysql.message.client;
 import io.asyncer.r2dbc.mysql.ConnectionContext;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import java.util.Objects;
 import reactor.core.publisher.Mono;
 
 import java.nio.charset.Charset;
@@ -65,6 +66,23 @@ public final class TextQueryMessage implements ClientMessage {
                 throw e;
             }
         });
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TextQueryMessage that = (TextQueryMessage) o;
+        return Objects.equals(sql, that.sql);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sql);
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Aligning Connection#setTransactionIsolationLevel Behavior with r2dbc-spi Specification. See https://github.com/asyncer-io/r2dbc-mysql/issues/192 for more.

Modification:

Change session isolation level as well after invoking `Connection#setTransactionIsolationLevel`.

Result:

All subsequent transactions will be applied the isolation level set by `Connection#setTransactionIsolationLevel`.