### PR TITLE
Add support for MariaDB version pattern

### DIFF
--- a/src/main/java/io/asyncer/r2dbc/mysql/Capability.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/Capability.java
@@ -175,6 +175,11 @@ public final class Capability {
 
     private final long bitmap;
 
+    /**
+     * Checks if the connection is using MariaDB capabilities.
+     *
+     * @return if using MariaDB capabilities.
+     */
     public boolean isMariaDb() {
         return (bitmap & CLIENT_MYSQL) == 0;
     }

--- a/src/main/java/io/asyncer/r2dbc/mysql/ConnectionContext.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/ConnectionContext.java
@@ -98,6 +98,11 @@ public final class ConnectionContext implements CodecContext {
         return serverZoneId;
     }
 
+    @Override
+    public boolean isMariaDb() {
+        return capability.isMariaDb() || serverVersion.isMariaDb();
+    }
+
     boolean shouldSetServerZoneId() {
         return serverZoneId == null;
     }

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlColumnDescriptor.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlColumnDescriptor.java
@@ -122,7 +122,7 @@ final class MySqlColumnDescriptor implements MySqlColumnMetadata {
     @Override
     public CharCollation getCharCollation(CodecContext context) {
         return collationId == CharCollation.BINARY_ID ? context.getClientCollation() :
-            CharCollation.fromId(collationId, context.getServerVersion());
+            CharCollation.fromId(collationId, context);
     }
 
     @Override

--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/CodecContext.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/CodecContext.java
@@ -54,4 +54,11 @@ public interface CodecContext {
      * @return the {@link CharCollation}.
      */
     CharCollation getClientCollation();
+
+    /**
+     * Checks server is MariaDB or not.
+     *
+     * @return if is MariaDB.
+     */
+    boolean isMariaDb();
 }

--- a/src/main/java/io/asyncer/r2dbc/mysql/collation/CharCollation.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/collation/CharCollation.java
@@ -16,7 +16,7 @@
 
 package io.asyncer.r2dbc.mysql.collation;
 
-import io.asyncer.r2dbc.mysql.ServerVersion;
+import io.asyncer.r2dbc.mysql.codec.CodecContext;
 
 import java.nio.charset.Charset;
 
@@ -62,17 +62,17 @@ public interface CharCollation {
 
     /**
      * Obtain an instance of {@link CharCollation} from the identifier and server version, if not found, it
-     * will fallback to UTF-8. (i.e. utf8mb4)
+     * will fall back to UTF-8. (i.e. utf8mb4)
      *
      * @param id      character collation identifier.
-     * @param version the version of MySQL server.
+     * @param context the codec context of server.
      * @return the {@link CharCollation}.
      * @throws IllegalArgumentException if {@code version} is {@code null}.
      */
-    static CharCollation fromId(int id, ServerVersion version) {
-        requireNonNull(version, "version must not be null");
+    static CharCollation fromId(int id, CodecContext context) {
+        requireNonNull(context, "version must not be null");
 
-        return CharCollations.fromId(id, version);
+        return CharCollations.fromId(id, context);
     }
 
     /**

--- a/src/main/java/io/asyncer/r2dbc/mysql/collation/CharCollations.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/collation/CharCollations.java
@@ -17,6 +17,7 @@
 package io.asyncer.r2dbc.mysql.collation;
 
 import io.asyncer.r2dbc.mysql.ServerVersion;
+import io.asyncer.r2dbc.mysql.codec.CodecContext;
 
 /**
  * A constant utility that is contains all {@link CharCollation}s.
@@ -41,11 +42,11 @@ final class CharCollations {
      * <p>
      * Note: all IDs must bigger than the max ID of universe.
      *
-     * @see #fromId(int, ServerVersion)
+     * @see #fromId(int, CodecContext)
      */
     private static final CharCollation[] EXTRA;
 
-    private static final ServerVersion UTF8MB4_0900_VER = ServerVersion.create(8, 0, 1);
+    private static final ServerVersion MYSQL_8_0_1 = ServerVersion.create(8, 0, 1);
 
     static {
         // The initialization of character collation constants is the premise of the universe big bang.
@@ -66,7 +67,7 @@ final class CharCollations {
 
     private CharCollations() { }
 
-    static CharCollation fromId(int id, ServerVersion version) {
+    static CharCollation fromId(int id, CodecContext context) {
         if (id < 0 || id >= COSMOS.length) {
             for (CharCollation collation : EXTRA) {
                 if (collation.getId() == id) {
@@ -74,24 +75,24 @@ final class CharCollations {
                 }
             }
 
-            return defaultServerCollation(version);
+            return defaultServerCollation(context);
         }
 
         CharCollation collation = COSMOS[id];
 
         if (collation == null) {
-            return defaultServerCollation(version);
+            return defaultServerCollation(context);
         }
 
         return collation;
     }
 
-    private static CharCollation defaultServerCollation(ServerVersion version) {
-        if (version.isGreaterThanOrEqualTo(UTF8MB4_0900_VER)) {
-            return UTF8MB4_0900_AI_CI;
+    private static CharCollation defaultServerCollation(CodecContext context) {
+        if (context.isMariaDb() || context.getServerVersion().isLessThan(MYSQL_8_0_1)) {
+            return UTF8MB4_GENERAL_CI;
         }
 
-        return UTF8MB4_GENERAL_CI;
+        return UTF8MB4_0900_AI_CI;
     }
 
     private static int cosmosSize(CharCollation[] universe) {

--- a/src/test/java/io/asyncer/r2dbc/mysql/ServerVersionTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/ServerVersionTest.java
@@ -17,7 +17,10 @@
 package io.asyncer.r2dbc.mysql;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -114,5 +117,18 @@ class ServerVersionTest {
         assertEquals(ServerVersion.parse("56.78.910RC2").toString(), "56.78.910RC2");
         assertEquals(ServerVersion.parse("56.78.910-v2").toString(), "56.78.910-v2");
         assertEquals(ServerVersion.parse("56.78.910-RC2").toString(), "56.78.910-RC2");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "5.5.5-10", "8.0.MariaDB", "8-MariaDB",
+        "10.1-MariaDB", "5.5.5-10.11.22-MariaDB",
+        "11.2.22-MariaDB", "11.2.22-MariaDB-1~jessie", "10.1.44-MariaDB-0+deb9u1",
+    })
+    void mariaDbVersion(String version) {
+        ServerVersion ver = ServerVersion.parse(version);
+
+        assertThat(ver.isMariaDb()).isTrue();
+        assertThat(ver.isGreaterThanOrEqualTo(ServerVersion.create(6, 0, 0))).isTrue();
     }
 }

--- a/src/test/java/io/asyncer/r2dbc/mysql/codec/CodecsTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/codec/CodecsTest.java
@@ -81,7 +81,7 @@ class CodecsTest {
 
         @Override
         public CharCollation getCharCollation(CodecContext context) {
-            return CharCollation.fromId(CharCollation.BINARY_ID, context.getServerVersion());
+            return CharCollation.fromId(CharCollation.BINARY_ID, context);
         }
 
         @Override

--- a/src/test/java/io/asyncer/r2dbc/mysql/collation/CharCollationTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/collation/CharCollationTest.java
@@ -16,7 +16,8 @@
 
 package io.asyncer.r2dbc.mysql.collation;
 
-import io.asyncer.r2dbc.mysql.ServerVersion;
+import io.asyncer.r2dbc.mysql.ConnectionContext;
+import io.asyncer.r2dbc.mysql.ConnectionContextTest;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -27,16 +28,16 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  */
 class CharCollationTest {
 
-    private static final ServerVersion version = ServerVersion.create(0, 0, 0);
+    private final ConnectionContext context = ConnectionContextTest.mock();
 
     @Test
     void fromId() {
-        assertNotNull(CharCollation.fromId(33, version)); // utf8 general case insensitivity
-        assertNotNull(CharCollation.fromId(45, version)); // utf8mb4 general case insensitivity
-        assertNotNull(CharCollation.fromId(224, version)); // utf8mb4 unicode case insensitivity
-        assertNotNull(CharCollation.fromId(246, version)); // utf8mb4 unicode 5.20 case insensitivity
+        assertNotNull(CharCollation.fromId(33, context)); // utf8 general case insensitivity
+        assertNotNull(CharCollation.fromId(45, context)); // utf8mb4 general case insensitivity
+        assertNotNull(CharCollation.fromId(224, context)); // utf8mb4 unicode case insensitivity
+        assertNotNull(CharCollation.fromId(246, context)); // utf8mb4 unicode 5.20 case insensitivity
         // utf8mb4 unicode 9.00 accent insensitivity and case insensitivity
-        assertNotNull(CharCollation.fromId(255, version));
-        assertNotEquals(CharCollation.fromId(33, version), CharCollation.fromId(224, version));
+        assertNotNull(CharCollation.fromId(255, context));
+        assertNotEquals(CharCollation.fromId(33, context), CharCollation.fromId(224, context));
     }
 }


### PR DESCRIPTION
Motivation:

Should remove fake prefix `5.5.5-` for MariaDB 10.x

See also #203 

This is why #201 cannot assert that the server supports `RETURNING` clause.

Modification:

- Check and remove MariaDB version fake prefix
- Add `isMariaDb` to `ConnectionContext`, it will check  either capabilities or server version is present as MariaDB
- Correct server version checking, like TLS version, `@@transaction_isolation`/`@@tx_isolation`

Result:

Driver correctly parses and checks MariaDB server version