### PR TITLE
Fix NPE issue when batch execution is called without any queries

### DIFF
--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlBatchingBatch.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlBatchingBatch.java
@@ -20,6 +20,8 @@ import io.asyncer.r2dbc.mysql.client.Client;
 import io.asyncer.r2dbc.mysql.codec.Codecs;
 import reactor.core.publisher.Flux;
 
+import java.util.StringJoiner;
+
 import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.requireNonNull;
 
 /**
@@ -34,7 +36,7 @@ final class MySqlBatchingBatch extends MySqlBatch {
 
     private final ConnectionContext context;
 
-    private StringBuilder builder;
+    private final StringJoiner queries = new StringJoiner(";");
 
     MySqlBatchingBatch(Client client, Codecs codecs, ConnectionContext context) {
         this.client = requireNonNull(client, "client must not be null");
@@ -50,9 +52,9 @@ final class MySqlBatchingBatch extends MySqlBatch {
 
         if (index >= 0 && sql.charAt(index) == ';') {
             // Skip last ';' and whitespaces that following last ';'.
-            requireBuilder().append(sql, 0, index);
+            queries.add(sql.substring(0, index));
         } else {
-            requireBuilder().append(sql);
+            queries.add(sql);
         }
 
         return this;
@@ -60,10 +62,6 @@ final class MySqlBatchingBatch extends MySqlBatch {
 
     @Override
     public Flux<MySqlResult> execute() {
-        if (builder == null) {
-            return Flux.empty();
-        }
-
         return QueryFlow.execute(client, getSql())
             .map(messages -> MySqlResult.toResult(false, codecs, context, null, messages));
     }
@@ -79,15 +77,7 @@ final class MySqlBatchingBatch extends MySqlBatch {
      * @return current batching SQL statement
      */
     String getSql() {
-        return builder.toString();
-    }
-
-    private StringBuilder requireBuilder() {
-        if (builder == null) {
-            return (builder = new StringBuilder());
-        }
-
-        return builder.append(';');
+        return queries.toString();
     }
 
     private static int lastNonWhitespace(String sql) {

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlBatchingBatch.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlBatchingBatch.java
@@ -60,6 +60,10 @@ final class MySqlBatchingBatch extends MySqlBatch {
 
     @Override
     public Flux<MySqlResult> execute() {
+        if (builder == null) {
+            return Flux.empty();
+        }
+
         return QueryFlow.execute(client, getSql())
             .map(messages -> MySqlResult.toResult(false, codecs, context, null, messages));
     }

--- a/src/test/java/io/asyncer/r2dbc/mysql/MySqlBatchingBatchTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/MySqlBatchingBatchTest.java
@@ -61,9 +61,9 @@ class MySqlBatchingBatchTest {
     }
 
     @Test
-    void executeNothing() {
-        MySqlBatchingBatch batch = new MySqlBatchingBatch(mock(Client.class), mock(Codecs.class),
+    void addNothing() {
+        final MySqlBatchingBatch batch = new MySqlBatchingBatch(mock(Client.class), mock(Codecs.class),
             ConnectionContextTest.mock());
-        assertEquals(batch.execute().blockFirst(), null);
+        assertEquals(batch.getSql(), "");
     }
 }

--- a/src/test/java/io/asyncer/r2dbc/mysql/MySqlBatchingBatchTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/MySqlBatchingBatchTest.java
@@ -59,4 +59,11 @@ class MySqlBatchingBatchTest {
     void badAdd() {
         assertThrows(IllegalArgumentException.class, () -> batch.add(null));
     }
+
+    @Test
+    void executeNothing() {
+        MySqlBatchingBatch batch = new MySqlBatchingBatch(mock(Client.class), mock(Codecs.class),
+            ConnectionContextTest.mock());
+        assertEquals(batch.execute().blockFirst(), null);
+    }
 }


### PR DESCRIPTION
Motivation:
(Please describe the problem you are trying to solve, or the new feature you are trying to add.)

we're using this R2DBC client with jOOQ.
NPE occurs when we give empty list to `DSLContext#batch`

```kotlin
val queries = emptyList()
dslContext.batch(queries).awaitLast()
```

this is because `StringBuilder` in `MySqlBatchingBatch` is not initialized until `add` method is called.
so, `execute` method will refer to not-initialized `builder` when `add` method is not called.

Modification:
(Please describe the changes you have made to the codebase, including any new files, modified files, or deleted files.)

~~modify `execute` to return `Flux#empty` when ` builder` is not initialized (i.e., `add` method is not called).~~
send empty string to client without NPE

Result:
(Please describe the expected outcome of your changes, and any potential side effects or drawbacks. 
If possible, please also include any relevant testing results.)

it now does not throw NPE ~~but returns empty flux instead.~~