### PR TITLE
Fix BooleanCodec

### DIFF
--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/BooleanCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/BooleanCodec.java
@@ -72,7 +72,7 @@ final class BooleanCodec extends AbstractPrimitiveCodec<Boolean> {
 
         @Override
         public Mono<Void> publishText(ParameterWriter writer) {
-            return Mono.fromRunnable(() -> writer.writeBinary(value));
+            return Mono.fromRunnable(() -> writer.writeInt(value ? 1 : 0));
         }
 
         @Override

--- a/src/test/java/io/asyncer/r2dbc/mysql/codec/BooleanCodecTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/codec/BooleanCodecTest.java
@@ -41,7 +41,7 @@ class BooleanCodecTest implements CodecTestSupport<Boolean> {
 
     @Override
     public Object[] stringifyParameters() {
-        return Arrays.stream(booleans).map(it -> it ? "b'1'" : "b'0'").toArray();
+        return Arrays.stream(booleans).map(it -> it ? "1" : "0").toArray();
     }
 
     @Override


### PR DESCRIPTION
Motivation:
Address the current issue with BooleanCodec encoding booleans as binary, which can lead to unintended results.

Modification:
Update BooleanCodec to encode booleans as integers (1 for true, 0 for false).

Result:
Aligns with https://dev.mysql.com/doc/refman/8.0/en/boolean-literals.html
Ensures accurate boolean encoding.
Fixes #209.