### PR TITLE
Singleton `BooleanMySqlParameter`

### DIFF
--- a/src/main/java/io/asyncer/r2dbc/mysql/codec/BooleanCodec.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/codec/BooleanCodec.java
@@ -48,7 +48,7 @@ final class BooleanCodec extends AbstractPrimitiveCodec<Boolean> {
 
     @Override
     public MySqlParameter encode(Object value, CodecContext context) {
-        return new BooleanMySqlParameter((Boolean) value);
+        return (Boolean) value? BooleanMySqlParameter.TRUE : BooleanMySqlParameter.FALSE;
     }
 
     @Override
@@ -58,6 +58,10 @@ final class BooleanCodec extends AbstractPrimitiveCodec<Boolean> {
     }
 
     private static final class BooleanMySqlParameter extends AbstractMySqlParameter {
+
+        private static final BooleanMySqlParameter TRUE = new BooleanMySqlParameter(true);
+
+        private static final BooleanMySqlParameter FALSE = new BooleanMySqlParameter(false);
 
         private final boolean value;
 


### PR DESCRIPTION
Motivation:
Enhance resource management and consistency by adopting a singleton pattern in `BooleanMySqlParameter`.

Modification:
Restructured BooleanMySqlParameter to allow only one instance, ensuring efficient usage.

Result:
Optimized performance and uniformity in handling MySQL boolean parameters with a singleton BooleanMySqlParameter.