### PR TITLE
Add lightweight ping syntax support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This driver provides the following features:
 - [x] Secure connection with verification (SSL/TLS), auto-select TLS version for community and enterprise editions.
 - [x] SSL tunnel for proxy protocol of MySQL.
 - [x] Transactions with savepoint.
-- [x] Native ping command that can be verifying when argument is `ValidationDepth.REMOTE`
+- [x] Native ping can be sent via `Connection.validate(ValidationDepth.REMOTE)` and the lightweight ping syntax `/* ping */ ...`.
 - [x] Extensible, e.g. extend built-in `Codec`(s).
 - [x] MariaDB `RETURNING` clause.
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlStatement.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlStatement.java
@@ -19,6 +19,9 @@ package io.asyncer.r2dbc.mysql;
 import io.r2dbc.spi.Statement;
 import reactor.core.publisher.Flux;
 
+import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.require;
+import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.requireNonNull;
+
 /**
  * A strongly typed implementation of {@link Statement} for the MySQL database.
  */
@@ -58,17 +61,23 @@ public interface MySqlStatement extends Statement {
      * {@inheritDoc}
      */
     @Override
-    MySqlStatement returnGeneratedValues(String... columns);
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     Flux<MySqlResult> execute();
 
     /**
      * {@inheritDoc}
      */
     @Override
-    MySqlStatement fetchSize(int rows);
+    default MySqlStatement returnGeneratedValues(String... columns) {
+        requireNonNull(columns, "columns must not be null");
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    default MySqlStatement fetchSize(int rows) {
+        require(rows >= 0, "Fetch size must be greater or equal to zero");
+        return this;
+    }
 }

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlStatementSupport.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlStatementSupport.java
@@ -19,7 +19,6 @@ package io.asyncer.r2dbc.mysql;
 import io.asyncer.r2dbc.mysql.internal.util.InternalArrays;
 import org.jetbrains.annotations.Nullable;
 
-import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.require;
 import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.requireNonEmpty;
 import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.requireNonNull;
 
@@ -63,12 +62,6 @@ abstract class MySqlStatementSupport implements MySqlStatement {
             throw new IllegalArgumentException(db + " can have only one column");
         }
 
-        return this;
-    }
-
-    @Override
-    public MySqlStatement fetchSize(int rows) {
-        require(rows >= 0, "Fetch size must be greater or equal to zero");
         return this;
     }
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/PingStatement.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/PingStatement.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql;
+
+import io.asyncer.r2dbc.mysql.codec.Codecs;
+import reactor.core.publisher.Flux;
+
+/**
+ * An implementation of {@link MySqlStatement} considers the lightweight ping syntax.
+ */
+final class PingStatement implements MySqlStatement {
+
+    private final MySqlConnection connection;
+
+    private final Codecs codecs;
+
+    private final ConnectionContext context;
+
+    PingStatement(MySqlConnection connection, Codecs codecs, ConnectionContext context) {
+        this.connection = connection;
+        this.codecs = codecs;
+        this.context = context;
+    }
+
+    @Override
+    public MySqlStatement add() {
+        return this;
+    }
+
+    @Override
+    public MySqlStatement bind(int index, Object value) {
+        throw new UnsupportedOperationException("Binding parameters is not supported for ping");
+    }
+
+    @Override
+    public MySqlStatement bind(String name, Object value) {
+        throw new UnsupportedOperationException("Binding parameters is not supported for ping");
+    }
+
+    @Override
+    public MySqlStatement bindNull(int index, Class<?> type) {
+        throw new UnsupportedOperationException("Binding parameters is not supported for ping");
+    }
+
+    @Override
+    public MySqlStatement bindNull(String name, Class<?> type) {
+        throw new UnsupportedOperationException("Binding parameters is not supported for ping");
+    }
+
+    @Override
+    public Flux<MySqlResult> execute() {
+        return Flux.just(MySqlResult.toResult(false, codecs, context, null,
+            connection.doPingInternal()));
+    }
+}


### PR DESCRIPTION
Motivation:

Add lightweight ping syntax support.

See also #214 .

Modification:

- Add a `PingStatement`
- Add default impl for `MySqlStatement.returnGeneratedValues` and `MySqlStatement.fetchSize`
- Extract `MySqlConnection.doPingInternal` method for sending a MySQL ping

Result:

Any query starting with `/* ping */` will be changed to perform a MySQL ping.
