### PR TITLE
Init global variable to GitHub Actions instead of test code

### DIFF
--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -22,10 +22,15 @@ jobs:
       - name: Shutdown the Default MySQL
         run: sudo service mysql stop
       - name: Set up MySQL ${{ matrix.mysql-version }}
-        uses: asyncer-io/mysql-action@trunk
-        with:
-          mysql version: ${{ matrix.mysql-version }}
-          mysql database: r2dbc
-          mysql root password: r2dbc-password!@
+        env:
+          MYSQL_DATABASE: r2dbc
+          MYSQL_ROOT_PASSWORD: r2dbc-password!@
+          MYSQL_VERSION: ${{ matrix.mysql-version }}
+        run: docker-compose -f ${{ github.workspace }}/containers/mysql-compose.yml up -d
       - name: Integration test with MySQL ${{ matrix.mysql-version }}
-        run: ./mvnw -B verify -Dmaven.javadoc.skip=true -Dmaven.surefire.skip=true -Dtest.mysql.password=r2dbc-password!@ -Dtest.mysql.version=${{ matrix.mysql-version }} -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN
+        run: |
+          ./mvnw -B verify -Dmaven.javadoc.skip=true \
+          -Dmaven.surefire.skip=true \
+          -Dtest.mysql.password=r2dbc-password!@ \
+          -Dtest.mysql.version=${{ matrix.mysql-version }} \
+          -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN

--- a/containers/mysql-compose.yml
+++ b/containers/mysql-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+
+services:
+  mariadb:
+    image: mysql:${MYSQL_VERSION}
+    container_name: mysql_${MYSQL_VERSION}
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+    command: mysqld --local-infile=true --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    ports:
+      - "3306:3306"

--- a/src/test/java/io/asyncer/r2dbc/mysql/ConnectionIntegrationTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/ConnectionIntegrationTest.java
@@ -18,7 +18,6 @@ package io.asyncer.r2dbc.mysql;
 
 import io.r2dbc.spi.ColumnMetadata;
 import io.r2dbc.spi.R2dbcPermissionDeniedException;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -28,7 +27,6 @@ import org.testcontainers.shaded.com.fasterxml.jackson.databind.node.ArrayNode;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.node.ObjectNode;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -60,20 +58,6 @@ class ConnectionIntegrationTest extends IntegrationTestSupport {
 
     ConnectionIntegrationTest() {
         super(config);
-    }
-
-    @BeforeAll
-    static void initGlobalVariables() {
-        // TODO: move it to GitHub Actions instead of test code
-        MySqlConnectionFactory.from(config)
-            .create()
-            .flatMap(conn -> conn.createStatement("SET GLOBAL local_infile=ON")
-                .execute()
-                .flatMap(MySqlResult::getRowsUpdated)
-                .then(conn.close())
-                .onErrorResume(e -> conn.close().then(Mono.error(e))))
-            .as(StepVerifier::create)
-            .verifyComplete();
     }
 
     @Test


### PR DESCRIPTION
Motivation:

Should not init MySQL global variables in test code.

Modification:

- Change the MySQL setup to use `docker compose` instead
- Add init options of `mysqld`
- Remove global variable initialization from the test code

Result:

Global variables will be initialized on GitHub Actions.