### PR TITLE
Remove `socketTimeout`

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
     .option(DATABASE, "r2dbc") // optional, default null, null means not specifying the database
     .option(Option.valueOf("createDatabaseIfNotExist"), true) // optional, default false, create database if not exist (since 1.0.6 / 0.9.7)
     .option(CONNECT_TIMEOUT, Duration.ofSeconds(3)) // optional, default null, null means no timeout
-    .option(Option.valueOf("socketTimeout"), Duration.ofSeconds(4)) // deprecated since 1.0.1, because it has no effect and serves no purpose.
     .option(SSL, true) // optional, default sslMode is "preferred", it will be ignore if sslMode is set
     .option(Option.valueOf("sslMode"), "verify_identity") // optional, default "preferred"
     .option(Option.valueOf("sslCa"), "/path/to/mysql/ca.pem") // required when sslMode is verify_ca or verify_identity, default null, null means has no server CA cert
@@ -179,7 +178,6 @@ MySqlConnectionConfiguration configuration = MySqlConnectionConfiguration.builde
     .createDatabaseIfNotExist(true) // optional, default false, create database if not exist (since 1.0.6 / 0.9.7)
     .serverZoneId(ZoneId.of("Continent/City")) // optional, default null, null means query server time zone when connection init
     .connectTimeout(Duration.ofSeconds(3)) // optional, default null, null means no timeout
-    .socketTimeout(Duration.ofSeconds(4)) // deprecated since 1.0.1, because it has no effect and serves no purpose.
     .sslMode(SslMode.VERIFY_IDENTITY) // optional, default SslMode.PREFERRED
     .sslCa("/path/to/mysql/ca.pem") // required when sslMode is VERIFY_CA or VERIFY_IDENTITY, default null, null means has no server CA cert
     .sslCert("/path/to/mysql/client-cert.pem") // optional, default has no client SSL certificate
@@ -229,7 +227,6 @@ Mono<Connection> connectionMono = Mono.from(connectionFactory.create());
 | database | A valid MySQL database name | Optional, default does not initialize database | Database used by the MySQL connection |
 | createDatabaseIfNotExist | `true` or `false` | Optional, default `false` | Create database if not exist |
 | connectTimeout | A `Duration` which must be positive duration | Optional, default has no timeout | TCP connect timeout |
-| socketTimeout | A `Duration` which must be positive duration | Deprecated since 1.0.1 | TCP socket timeout |
 | serverZoneId | An id of `ZoneId` | Optional, default query time zone when connection init | Server time zone id |
 | tcpKeepAlive | `true` or `false` | Optional, default disabled | Controls TCP KeepAlive |
 | tcpNoDelay | `true` or `false` | Optional, default disabled | Controls TCP NoDelay |

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
@@ -72,9 +72,6 @@ public final class MySqlConnectionConfiguration {
     private final Duration connectTimeout;
 
     @Nullable
-    private final Duration socketTimeout;
-
-    @Nullable
     private final ZoneId serverZoneId;
 
     private final ZeroDateOption zeroDateOption;
@@ -108,7 +105,7 @@ public final class MySqlConnectionConfiguration {
     private MySqlConnectionConfiguration(
         boolean isHost, String domain, int port, MySqlSslConfiguration ssl,
         boolean tcpKeepAlive, boolean tcpNoDelay, @Nullable Duration connectTimeout,
-        @Nullable Duration socketTimeout, ZeroDateOption zeroDateOption, @Nullable ZoneId serverZoneId,
+        ZeroDateOption zeroDateOption, @Nullable ZoneId serverZoneId,
         String user, @Nullable CharSequence password, @Nullable String database,
         boolean createDatabaseIfNotExist, @Nullable Predicate<String> preferPrepareStatement,
         @Nullable Path loadLocalInfilePath, int localInfileBufferSize,
@@ -121,7 +118,6 @@ public final class MySqlConnectionConfiguration {
         this.tcpKeepAlive = tcpKeepAlive;
         this.tcpNoDelay = tcpNoDelay;
         this.connectTimeout = connectTimeout;
-        this.socketTimeout = socketTimeout;
         this.ssl = ssl;
         this.serverZoneId = serverZoneId;
         this.zeroDateOption = requireNonNull(zeroDateOption, "zeroDateOption must not be null");
@@ -162,16 +158,6 @@ public final class MySqlConnectionConfiguration {
     @Nullable
     Duration getConnectTimeout() {
         return connectTimeout;
-    }
-
-    /**
-     * @deprecated  This option has been deprecated as of version 1.0.1, because it has no effect and serves no purpose.
-     * Please remove any references to this option from your code, as it will be removed in a future release.
-     */
-    @Nullable
-    @Deprecated
-    Duration getSocketTimeout() {
-        return socketTimeout;
     }
 
     MySqlSslConfiguration getSsl() {
@@ -259,7 +245,6 @@ public final class MySqlConnectionConfiguration {
             tcpKeepAlive == that.tcpKeepAlive &&
             tcpNoDelay == that.tcpNoDelay &&
             Objects.equals(connectTimeout, that.connectTimeout) &&
-            Objects.equals(socketTimeout, that.socketTimeout) &&
             Objects.equals(serverZoneId, that.serverZoneId) &&
             zeroDateOption == that.zeroDateOption &&
             user.equals(that.user) &&
@@ -278,7 +263,7 @@ public final class MySqlConnectionConfiguration {
     @Override
     public int hashCode() {
         return Objects.hash(isHost, domain, port, ssl, tcpKeepAlive, tcpNoDelay, connectTimeout,
-            socketTimeout, serverZoneId, zeroDateOption, user, password, database, createDatabaseIfNotExist,
+            serverZoneId, zeroDateOption, user, password, database, createDatabaseIfNotExist,
             preferPrepareStatement, loadLocalInfilePath, localInfileBufferSize, queryCacheSize,
             prepareCacheSize, extensions, passwordPublisher);
     }
@@ -287,8 +272,8 @@ public final class MySqlConnectionConfiguration {
     public String toString() {
         if (isHost) {
             return "MySqlConnectionConfiguration{host='" + domain + "', port=" + port + ", ssl=" + ssl +
-                ", tcpNoDelay=" + tcpNoDelay + ", tcpKeepAlive=" + tcpKeepAlive + ", connectTimeout=" +
-                connectTimeout + ", socketTimeout=" + socketTimeout + ", serverZoneId=" + serverZoneId +
+                ", tcpNoDelay=" + tcpNoDelay + ", tcpKeepAlive=" + tcpKeepAlive +
+                ", connectTimeout=" + connectTimeout + ", serverZoneId=" + serverZoneId +
                 ", zeroDateOption=" + zeroDateOption + ", user='" + user + "', password=" + password +
                 ", database='" + database + "', createDatabaseIfNotExist=" + createDatabaseIfNotExist +
                 ", preferPrepareStatement=" + preferPrepareStatement +
@@ -298,8 +283,8 @@ public final class MySqlConnectionConfiguration {
                 ", extensions=" + extensions + ", passwordPublisher=" + passwordPublisher + '}';
         }
 
-        return "MySqlConnectionConfiguration{unixSocket='" + domain + "', connectTimeout=" +
-            connectTimeout + ", socketTimeout=" + socketTimeout + ", serverZoneId=" + serverZoneId +
+        return "MySqlConnectionConfiguration{unixSocket='" + domain +
+            "', connectTimeout=" + connectTimeout + ", serverZoneId=" + serverZoneId +
             ", zeroDateOption=" + zeroDateOption + ", user='" + user + "', password=" + password +
             ", database='" + database + "', createDatabaseIfNotExist=" + createDatabaseIfNotExist +
             ", preferPrepareStatement=" + preferPrepareStatement +
@@ -331,9 +316,6 @@ public final class MySqlConnectionConfiguration {
 
         @Nullable
         private Duration connectTimeout;
-
-        @Nullable
-        private Duration socketTimeout;
 
         private String user;
 
@@ -410,7 +392,7 @@ public final class MySqlConnectionConfiguration {
             MySqlSslConfiguration ssl = MySqlSslConfiguration.create(sslMode, tlsVersion, sslHostnameVerifier,
                 sslCa, sslKey, sslKeyPassword, sslCert, sslContextBuilderCustomizer);
             return new MySqlConnectionConfiguration(isHost, domain, port, ssl, tcpKeepAlive, tcpNoDelay,
-                connectTimeout, socketTimeout, zeroDateOption, serverZoneId, user, password, database,
+                connectTimeout, zeroDateOption, serverZoneId, user, password, database,
                 createDatabaseIfNotExist, preferPrepareStatement, loadLocalInfilePath,
                 localInfileBufferSize, queryCacheSize, prepareCacheSize,
                 Extensions.from(extensions, autodetectExtensions), passwordPublisher);
@@ -507,22 +489,6 @@ public final class MySqlConnectionConfiguration {
          */
         public Builder connectTimeout(@Nullable Duration connectTimeout) {
             this.connectTimeout = connectTimeout;
-            return this;
-        }
-
-        /**
-         * Configure the socket timeout, only for compatibility with {@code socketTimeout} property in the
-         * JDBC driver.  In fact, {@code SO_TIMEOUT} has effect only for OIO socket transport.  Default no
-         * timeout.
-         *
-         * @param socketTimeout the socket timeout, or {@code null} if has no timeout.
-         * @return this {@link Builder}.
-         * @since 0.8.6
-         * @deprecated This option has been deprecated as of version 1.0.1, because it has no effect and
-         * serves no purpose.
-         */
-        public Builder socketTimeout(@Nullable Duration socketTimeout) {
-            this.socketTimeout = socketTimeout;
             return this;
         }
 

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactory.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactory.java
@@ -138,7 +138,7 @@ public final class MySqlConnectionFactory implements ConnectionFactory {
             final int prepareCacheSize,
             @Nullable final CharSequence password) {
         return Client.connect(ssl, address, configuration.isTcpKeepAlive(), configuration.isTcpNoDelay(),
-                context, configuration.getConnectTimeout(), configuration.getSocketTimeout())
+                context, configuration.getConnectTimeout())
             .flatMap(client -> {
                 // Lazy init database after handshake/login
                 String db = createDbIfNotExist ? "" : database;

--- a/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
@@ -139,16 +139,6 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
         SSL_CONTEXT_BUILDER_CUSTOMIZER = Option.valueOf("sslContextBuilderCustomizer");
 
     /**
-     * TCP socket timeout
-     *
-     * @since 0.8.3
-     * @deprecated  This option has been deprecated as of version 1.0.1, because it has no effect and serves no purpose.
-     * Please remove any references to this option from your code, as it will be removed in a future release.
-     */
-    @Deprecated
-    public static final Option<Duration> SOCKET_TIMEOUT = Option.valueOf("socketTimeout");
-
-    /**
      * Enable/Disable TCP KeepAlive.
      *
      * @since 0.8.2
@@ -279,8 +269,6 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
             .to(builder::autodetectExtensions);
         mapper.optional(CONNECT_TIMEOUT).as(Duration.class, Duration::parse)
             .to(builder::connectTimeout);
-        mapper.optional(SOCKET_TIMEOUT).as(Duration.class, Duration::parse)
-            .to(builder::socketTimeout);
         mapper.optional(DATABASE).asString()
             .to(builder::database);
         mapper.optional(CREATE_DATABASE_IF_NOT_EXIST).asBoolean()

--- a/src/main/java/io/asyncer/r2dbc/mysql/client/Client.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/client/Client.java
@@ -116,15 +116,12 @@ public interface Client {
      * @param tcpNoDelay     if enable the {@link ChannelOption#TCP_NODELAY}
      * @param context        the connection context
      * @param connectTimeout connect timeout, or {@code null} if it has no timeout
-     * @param socketTimeout  socket timeout, or {@code null} if it has no timeout
      * @return A {@link Mono} that will emit a connected {@link Client}.
      * @throws IllegalArgumentException if {@code ssl}, {@code address} or {@code context} is {@code null}.
-     * @throws ArithmeticException      if {@code connectTimeout} or {@code socketTimeout} milliseconds
-     *                                  overflow as an int
+     * @throws ArithmeticException      if {@code connectTimeout} milliseconds overflow as an int
      */
     static Mono<Client> connect(MySqlSslConfiguration ssl, SocketAddress address, boolean tcpKeepAlive,
-        boolean tcpNoDelay, ConnectionContext context, @Nullable Duration connectTimeout,
-        @Nullable Duration socketTimeout) {
+        boolean tcpNoDelay, ConnectionContext context, @Nullable Duration connectTimeout) {
         requireNonNull(ssl, "ssl must not be null");
         requireNonNull(address, "address must not be null");
         requireNonNull(context, "context must not be null");
@@ -134,10 +131,6 @@ public interface Client {
         if (connectTimeout != null) {
             tcpClient = tcpClient.option(ChannelOption.CONNECT_TIMEOUT_MILLIS,
                 Math.toIntExact(connectTimeout.toMillis()));
-        }
-
-        if (socketTimeout != null) {
-            logger.warn("Socket timeout is not supported by the underlying connection and will be ignored.");
         }
 
         if (address instanceof InetSocketAddress) {

--- a/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfigurationTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfigurationTest.java
@@ -234,7 +234,6 @@ class MySqlConnectionConfigurationTest {
             .tcpKeepAlive(true)
             .tcpNoDelay(true)
             .connectTimeout(Duration.ofSeconds(3))
-            .socketTimeout(Duration.ofSeconds(4))
             .sslMode(SslMode.VERIFY_IDENTITY)
             .sslCa(SSL_CA)
             .sslCert("/path/to/mysql/client-cert.pem")

--- a/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProviderTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProviderTest.java
@@ -129,7 +129,6 @@ class MySqlConnectionFactoryProviderTest {
             .option(PASSWORD, "123456")
             .option(SSL, true)
             .option(Option.valueOf(CONNECT_TIMEOUT.name()), Duration.ofSeconds(3).toString())
-            .option(Option.valueOf("socketTimeout"), Duration.ofSeconds(4).toString())
             .option(DATABASE, "r2dbc")
             .option(Option.valueOf("serverZoneId"), "Asia/Tokyo")
             .option(Option.valueOf("useServerPrepareStatement"), AllTruePredicate.class.getName())
@@ -156,7 +155,6 @@ class MySqlConnectionFactoryProviderTest {
         assertThat(configuration.getUser()).isEqualTo("root");
         assertThat(configuration.getPassword()).isEqualTo("123456");
         assertThat(configuration.getConnectTimeout()).isEqualTo(Duration.ofSeconds(3));
-        assertThat(configuration.getSocketTimeout()).isEqualTo(Duration.ofSeconds(4));
         assertThat(configuration.getDatabase()).isEqualTo("r2dbc");
         assertThat(configuration.getZeroDateOption()).isEqualTo(ZeroDateOption.USE_ROUND);
         assertThat(configuration.isTcpKeepAlive()).isTrue();


### PR DESCRIPTION
Motivation:

See also #222

Modification:

Remove deprecated option `socketTimeout`.

Result:

The option `socketTimeout` is removed.