### PR TITLE
Add support for decoding session state info

### DIFF
--- a/src/main/java/io/asyncer/r2dbc/mysql/Capability.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/Capability.java
@@ -144,7 +144,11 @@ public final class Capability {
     private static final long VAR_INT_SIZED_AUTH = 1L << 21;
 
 //    private static final long HANDLE_EXPIRED_PASSWORD = 1L << 22; // Client can handle expired passwords.
-//    private static final long SESSION_TRACK = 1L << 23;
+
+    /**
+     * Server can send session state information in the OK packet.
+     */
+    private static final long SESSION_TRACK = 1L << 23;
 
     /**
      * The MySQL server marks the EOF message as deprecated and use OK message instead.
@@ -171,7 +175,7 @@ public final class Capability {
     private static final long ALL_SUPPORTED = CLIENT_MYSQL | FOUND_ROWS | LONG_FLAG | CONNECT_WITH_DB |
         NO_SCHEMA | COMPRESS | LOCAL_FILES | IGNORE_SPACE | PROTOCOL_41 | INTERACTIVE | SSL |
         TRANSACTIONS | SECURE_SALT | MULTI_STATEMENTS | MULTI_RESULTS | PS_MULTI_RESULTS |
-        PLUGIN_AUTH | CONNECT_ATTRS | VAR_INT_SIZED_AUTH | DEPRECATE_EOF;
+        PLUGIN_AUTH | CONNECT_ATTRS | VAR_INT_SIZED_AUTH | SESSION_TRACK | DEPRECATE_EOF;
 
     private final long bitmap;
 
@@ -375,6 +379,10 @@ public final class Capability {
 
         void disableSsl() {
             this.bitmap &= ~SSL;
+        }
+
+        void disableSessionTrack() {
+            this.bitmap &= ~SESSION_TRACK;
         }
 
         void disableConnectAttributes() {

--- a/src/main/java/io/asyncer/r2dbc/mysql/QueryFlow.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/QueryFlow.java
@@ -945,6 +945,7 @@ final class LoginExchangeable extends FluxExchangeable<Void> {
     private Capability clientCapability(Capability serverCapability) {
         Capability.Builder builder = serverCapability.mutate();
 
+        builder.disableSessionTrack();
         builder.disableDatabasePinned();
         builder.disableCompression();
         builder.disableIgnoreAmbiguitySpace();

--- a/src/test/java/io/asyncer/r2dbc/mysql/message/server/OkMessageTest.java
+++ b/src/test/java/io/asyncer/r2dbc/mysql/message/server/OkMessageTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql.message.server;
+
+import io.asyncer.r2dbc.mysql.ConnectionContext;
+import io.asyncer.r2dbc.mysql.ConnectionContextTest;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link OkMessage}.
+ */
+class OkMessageTest {
+
+    @Test
+    void decodeSessionVariables() {
+        boolean isMariaDb = "mariadb".equalsIgnoreCase(System.getProperty("test.db.type"));
+        ConnectionContext context = ConnectionContextTest.mock(isMariaDb);
+        OkMessage message = OkMessage.decode(true, sessionVariablesOk(), context);
+
+        assertThat(message.getAffectedRows()).isOne();
+        assertThat(message.getLastInsertId()).isEqualTo(2);
+        assertThat(message.getServerStatuses()).isEqualTo((short) 0x4000);
+        assertThat(message.getWarnings()).isEqualTo(3);
+        assertThat(message.getSystemVariable("autocommit")).isEqualTo("OFF");
+    }
+
+    private static ByteBuf sessionVariablesOk() {
+        return Unpooled.wrappedBuffer(new byte[] {
+            0,
+            1, 2, 0, 0x40, 3, 0, 0, 0x11, 0, 0xf, 0xa,
+            0x61, 0x75, 0x74, 0x6f, 0x63, 0x6f, 0x6d, 0x6d, 0x69, 0x74, 0x3, 0x4f, 0x46, 0x46,
+        });
+    }
+}


### PR DESCRIPTION
Motivation:

Add support for `SESSION_TRACK_SYSTEM_VARIABLES` track info decoding

See also #227 

Modification:

- Make `Capability.SESSION_TRACK` available and disabled by default
- Add `SESSION_TRACK_SYSTEM_VARIABLES` decoding in `OkMessage`

Result:

Session state information decoding support