### PR TITLE
Correct an unexpected fall through

### DIFF
--- a/src/main/java/io/asyncer/r2dbc/mysql/message/server/ServerMessageDecoder.java
+++ b/src/main/java/io/asyncer/r2dbc/mysql/message/server/ServerMessageDecoder.java
@@ -219,10 +219,13 @@ public final class ServerMessageDecoder {
                 } else if (EofMessage.isValidSize(byteSize)) {
                     return EofMessage.decode(buf);
                 }
+
+                break;
             case LOCAL_INFILE:
                 if (buf.readableBytes() > 1) {
                     return LocalInfileRequest.decode(buf, context);
                 }
+
                 break;
         }
 


### PR DESCRIPTION
Motivation:

An unexpected fall through, which should have no impact. Because no packets start with `0xFE` during the command phase, the byte size is greater than 1, and not be OK or EOF.

Modification:

Correct an unexpected fall through in `ServerDecoder`.

Result:

Corrected an unexpected fall through.