### PR TITLE
Correct version auto-update in workflow

### DIFF
--- a/.github/scripts/upgrade_native_image_version.sh
+++ b/.github/scripts/upgrade_native_image_version.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Copyright 2024 asyncer.io projects
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -e
+
+VERSION=$(grep 'project.dev.io.asyncer\\:r2dbc-mysql=' r2dbc-mysql/release.properties | cut -d'=' -f2)
+
+echo 'Set test-native-image version to' $VERSION
+./mvnw -pl test-native-image versions:set -DnewVersion=$VERSION
+git add test-native-image/pom.xml

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -47,9 +47,16 @@ jobs:
           key: ${{ runner.os }}-prepare-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-prepare-
 
+      - name: DryRun Release Prepare
+        run: |
+          ./mvnw -B -ntp -pl r2dbc-mysql release:prepare -DpreparationGoals=clean -DdryRun=true -DskipTests=true
+
+      - name: Upgrade Native Image Version
+        run: ./.github/scripts/upgrade_native_image_version.sh
+
       - name: Run release prepare command
         run: |
-          ./mvnw -B -ntp -pl r2dbc-mysql release:prepare -DpreparationGoals=clean -DskipTests=true
+          ./mvnw -B -ntp -pl r2dbc-mysql release:prepare -DpreparationGoals=clean -Dresume=false -DskipTests=true
           ./mvnw -B -ntp clean
 
       - name: Ensure Prepared

--- a/test-native-image/pom.xml
+++ b/test-native-image/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.asyncer</groupId>
   <artifactId>test-native-image</artifactId>
-  <version>1.1.2-SNAPSHOT</version>
+  <version>1.1.3-SNAPSHOT</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Motivation:

The version of `test-native-image` will not be updated after the release is completed, which causes CI to fail after releasing.

Modification:

- Upgrade `test-native-image` to `1.1.3-SNAPSHOT`
- Correct version auto-update in workflow

Result:

Now the version of `test-native-image` should be updated automatically.
