### PR TITLE
Add support for multiple hosts configuration

### DIFF
--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/ConnectionStrategy.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/ConnectionStrategy.java
@@ -17,6 +17,7 @@
 package io.asyncer.r2dbc.mysql;
 
 import io.asyncer.r2dbc.mysql.client.Client;
+import io.asyncer.r2dbc.mysql.client.ReactorNettyClient;
 import io.asyncer.r2dbc.mysql.internal.util.StringUtils;
 import io.netty.channel.ChannelOption;
 import io.netty.resolver.AddressResolver;
@@ -26,6 +27,8 @@ import io.netty.resolver.RoundRobinInetAddressResolver;
 import io.netty.util.concurrent.EventExecutor;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
+import io.r2dbc.spi.R2dbcNonTransientResourceException;
+import org.jetbrains.annotations.Nullable;
 import reactor.core.publisher.Mono;
 import reactor.netty.resources.LoopResources;
 import reactor.netty.tcp.TcpClient;
@@ -33,6 +36,8 @@ import reactor.netty.tcp.TcpClient;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.time.ZoneId;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * An interface of a connection strategy that considers how to obtain a MySQL {@link Client} object.
@@ -49,7 +54,7 @@ interface ConnectionStrategy {
      *
      * @return a logged-in {@link Client} object.
      */
-    Mono<Client> connect();
+    Mono<? extends Client> connect();
 
     /**
      * Creates a general-purpose {@link TcpClient} with the given {@link SocketClientConfiguration}.
@@ -87,7 +92,7 @@ interface ConnectionStrategy {
      * @param configuration a configuration that affects login behavior.
      * @return a logged-in {@link Client} object.
      */
-    static Mono<Client> connectWithInit(
+    static Mono<ReactorNettyClient> connectWithInit(
         TcpClient tcpClient,
         Credential credential,
         MySqlConnectionConfiguration configuration
@@ -110,7 +115,7 @@ interface ConnectionStrategy {
                 configuration.isPreserveInstants(),
                 connectionTimeZone
             );
-        }).flatMap(context -> Client.connect(tcpClient, configuration.getSsl(), context)).flatMap(client -> {
+        }).flatMap(ctx -> ReactorNettyClient.connect(tcpClient, configuration.getSsl(), ctx)).flatMap(client -> {
             // Lazy init database after handshake/login
             MySqlSslConfiguration ssl = configuration.getSsl();
             String loginDb = configuration.isCreateDatabaseIfNotExist() ? "" : configuration.getDatabase();
@@ -126,30 +131,88 @@ interface ConnectionStrategy {
             ).then(Mono.just(client)).onErrorResume(e -> client.forceClose().then(Mono.error(e)));
         });
     }
-}
 
-/**
- * Resolves the {@link InetSocketAddress} to IP address, randomly pick one if it resolves to multiple IP addresses.
- *
- * @since 1.2.0
- */
-final class BalancedResolverGroup extends AddressResolverGroup<InetSocketAddress> {
-
-    BalancedResolverGroup() {
+    /**
+     * Creates an exception that indicates a retry failure.
+     *
+     * @param message the message of the exception.
+     * @param cause   the last exception that caused the retry.
+     * @return a retry failure exception.
+     */
+    static R2dbcNonTransientResourceException retryFail(String message, @Nullable Throwable cause) {
+        return new R2dbcNonTransientResourceException(
+            message,
+            "H1000",
+            9000,
+            cause
+        );
     }
 
-    public static final BalancedResolverGroup INSTANCE;
+    /**
+     * Connect and login to a MySQL server with a specific TCP socket address.
+     *
+     * @since 1.2.0
+     */
+    final class InetConnectFunction implements Function<Supplier<InetSocketAddress>, Mono<ReactorNettyClient>> {
 
-    static {
-        INSTANCE = new BalancedResolverGroup();
-        Runtime.getRuntime().addShutdownHook(new Thread(
-            INSTANCE::close,
-            "R2DBC-MySQL-BalancedResolverGroup-ShutdownHook"
-        ));
+        private final boolean balancedDns;
+
+        private final boolean tcpKeepAlive;
+
+        private final boolean tcpNoDelay;
+
+        private final Credential credential;
+
+        private final MySqlConnectionConfiguration configuration;
+
+        InetConnectFunction(
+            boolean balancedDns,
+            boolean tcpKeepAlive,
+            boolean tcpNoDelay,
+            Credential credential,
+            MySqlConnectionConfiguration configuration
+        ) {
+            this.balancedDns = balancedDns;
+            this.tcpKeepAlive = tcpKeepAlive;
+            this.tcpNoDelay = tcpNoDelay;
+            this.credential = credential;
+            this.configuration = configuration;
+        }
+
+        @Override
+        public Mono<ReactorNettyClient> apply(Supplier<InetSocketAddress> address) {
+            TcpClient client = ConnectionStrategy.createTcpClient(configuration.getClient(), balancedDns)
+                .option(ChannelOption.SO_KEEPALIVE, tcpKeepAlive)
+                .option(ChannelOption.TCP_NODELAY, tcpNoDelay)
+                .remoteAddress(address);
+
+            return ConnectionStrategy.connectWithInit(client, credential, configuration);
+        }
     }
 
-    @Override
-    protected AddressResolver<InetSocketAddress> newResolver(EventExecutor executor) {
-        return new RoundRobinInetAddressResolver(executor, new DefaultNameResolver(executor)).asAddressResolver();
+    /**
+     * Resolves the {@link InetSocketAddress} to IP address, randomly pick one if it resolves to multiple IP addresses.
+     *
+     * @since 1.2.0
+     */
+    final class BalancedResolverGroup extends AddressResolverGroup<InetSocketAddress> {
+
+        BalancedResolverGroup() {
+        }
+
+        public static final BalancedResolverGroup INSTANCE;
+
+        static {
+            INSTANCE = new BalancedResolverGroup();
+            Runtime.getRuntime().addShutdownHook(new Thread(
+                INSTANCE::close,
+                "R2DBC-MySQL-BalancedResolverGroup-ShutdownHook"
+            ));
+        }
+
+        @Override
+        protected AddressResolver<InetSocketAddress> newResolver(EventExecutor executor) {
+            return new RoundRobinInetAddressResolver(executor, new DefaultNameResolver(executor)).asAddressResolver();
+        }
     }
 }

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/ConnectionStrategy.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/ConnectionStrategy.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2024 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql;
+
+import io.asyncer.r2dbc.mysql.client.Client;
+import io.asyncer.r2dbc.mysql.internal.util.StringUtils;
+import io.netty.channel.ChannelOption;
+import io.netty.resolver.AddressResolver;
+import io.netty.resolver.AddressResolverGroup;
+import io.netty.resolver.DefaultNameResolver;
+import io.netty.resolver.RoundRobinInetAddressResolver;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+import reactor.core.publisher.Mono;
+import reactor.netty.resources.LoopResources;
+import reactor.netty.tcp.TcpClient;
+
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.time.ZoneId;
+
+/**
+ * An interface of a connection strategy that considers how to obtain a MySQL {@link Client} object.
+ *
+ * @since 1.2.0
+ */
+@FunctionalInterface
+interface ConnectionStrategy {
+
+    InternalLogger logger = InternalLoggerFactory.getInstance(ConnectionStrategy.class);
+
+    /**
+     * Establish a connection to a target server that is determined by this connection strategy.
+     *
+     * @return a logged-in {@link Client} object.
+     */
+    Mono<Client> connect();
+
+    /**
+     * Creates a general-purpose {@link TcpClient} with the given {@link SocketClientConfiguration}.
+     * <p>
+     * Note: Unix Domain Socket also uses this method to create a general-purpose {@link TcpClient client}.
+     *
+     * @param configuration socket client configuration.
+     * @return a general-purpose {@link TcpClient client}.
+     */
+    static TcpClient createTcpClient(SocketClientConfiguration configuration, boolean balancedDns) {
+        LoopResources loopResources = configuration.getLoopResources();
+        Duration connectTimeout = configuration.getConnectTimeout();
+        TcpClient client = TcpClient.newConnection();
+
+        if (loopResources != null) {
+            client = client.runOn(loopResources);
+        }
+
+        if (connectTimeout != null) {
+            client = client.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, Math.toIntExact(connectTimeout.toMillis()));
+        }
+
+        if (balancedDns) {
+            client = client.resolver(BalancedResolverGroup.INSTANCE);
+        }
+
+        return client;
+    }
+
+    /**
+     * Logins to a MySQL server with the given {@link TcpClient}, {@link Credential} and configurations.
+     *
+     * @param tcpClient     a TCP client to connect to a MySQL server.
+     * @param credential    user and password to log in to a MySQL server.
+     * @param configuration a configuration that affects login behavior.
+     * @return a logged-in {@link Client} object.
+     */
+    static Mono<Client> connectWithInit(
+        TcpClient tcpClient,
+        Credential credential,
+        MySqlConnectionConfiguration configuration
+    ) {
+        return Mono.fromSupplier(() -> {
+            String timeZone = configuration.getConnectionTimeZone();
+            ZoneId connectionTimeZone;
+            if ("LOCAL".equalsIgnoreCase(timeZone)) {
+                connectionTimeZone = ZoneId.systemDefault().normalized();
+            } else if ("SERVER".equalsIgnoreCase(timeZone)) {
+                connectionTimeZone = null;
+            } else {
+                connectionTimeZone = StringUtils.parseZoneId(timeZone);
+            }
+
+            return new ConnectionContext(
+                configuration.getZeroDateOption(),
+                configuration.getLoadLocalInfilePath(),
+                configuration.getLocalInfileBufferSize(),
+                configuration.isPreserveInstants(),
+                connectionTimeZone
+            );
+        }).flatMap(context -> Client.connect(tcpClient, configuration.getSsl(), context)).flatMap(client -> {
+            // Lazy init database after handshake/login
+            MySqlSslConfiguration ssl = configuration.getSsl();
+            String loginDb = configuration.isCreateDatabaseIfNotExist() ? "" : configuration.getDatabase();
+
+            return InitFlow.initHandshake(
+                client,
+                ssl.getSslMode(),
+                loginDb,
+                credential.getUser(),
+                credential.getPassword(),
+                configuration.getCompressionAlgorithms(),
+                configuration.getZstdCompressionLevel()
+            ).then(Mono.just(client)).onErrorResume(e -> client.forceClose().then(Mono.error(e)));
+        });
+    }
+}
+
+/**
+ * Resolves the {@link InetSocketAddress} to IP address, randomly pick one if it resolves to multiple IP addresses.
+ *
+ * @since 1.2.0
+ */
+final class BalancedResolverGroup extends AddressResolverGroup<InetSocketAddress> {
+
+    BalancedResolverGroup() {
+    }
+
+    public static final BalancedResolverGroup INSTANCE;
+
+    static {
+        INSTANCE = new BalancedResolverGroup();
+        Runtime.getRuntime().addShutdownHook(new Thread(
+            INSTANCE::close,
+            "R2DBC-MySQL-BalancedResolverGroup-ShutdownHook"
+        ));
+    }
+
+    @Override
+    protected AddressResolver<InetSocketAddress> newResolver(EventExecutor executor) {
+        return new RoundRobinInetAddressResolver(executor, new DefaultNameResolver(executor)).asAddressResolver();
+    }
+}

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/Credential.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/Credential.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+/**
+ * A value object representing a user with an optional password.
+ */
+final class Credential {
+
+    private final String user;
+
+    @Nullable
+    private final CharSequence password;
+
+    Credential(String user, @Nullable CharSequence password) {
+        this.user = user;
+        this.password = password;
+    }
+
+    String getUser() {
+        return user;
+    }
+
+    @Nullable
+    CharSequence getPassword() {
+        return password;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Credential)) {
+            return false;
+        }
+
+        Credential that = (Credential) o;
+
+        return user.equals(that.user) && Objects.equals(password, that.password);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * user.hashCode() + Objects.hashCode(password);
+    }
+
+    @Override
+    public String toString() {
+        return "Credential{user=" + user + ", password=REDACTED}";
+    }
+}

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/InitFlow.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/InitFlow.java
@@ -22,6 +22,7 @@ import io.asyncer.r2dbc.mysql.cache.Caches;
 import io.asyncer.r2dbc.mysql.cache.PrepareCache;
 import io.asyncer.r2dbc.mysql.client.Client;
 import io.asyncer.r2dbc.mysql.client.FluxExchangeable;
+import io.asyncer.r2dbc.mysql.client.ReactorNettyClient;
 import io.asyncer.r2dbc.mysql.codec.Codecs;
 import io.asyncer.r2dbc.mysql.codec.CodecsBuilder;
 import io.asyncer.r2dbc.mysql.constant.CompressionAlgorithm;
@@ -75,7 +76,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 /**
- * A message flow utility that can initializes the session of {@link Client}.
+ * A message flow utility that can initializes the session of {@link ReactorNettyClient}.
  * <p>
  * It should not use server-side prepared statements, because {@link PrepareCache} will be initialized after the session
  * is initialized.
@@ -117,9 +118,9 @@ final class InitFlow {
     };
 
     /**
-     * Initializes handshake and login a {@link Client}.
+     * Initializes handshake and login a {@link ReactorNettyClient}.
      *
-     * @param client                the {@link Client} to exchange messages with.
+     * @param client                the {@link ReactorNettyClient} to exchange messages with.
      * @param sslMode               the {@link SslMode} defines SSL capability and behavior.
      * @param database              the database that will be connected.
      * @param user                  the user that will be login.
@@ -128,7 +129,7 @@ final class InitFlow {
      * @param zstdCompressionLevel  the zstd compression level.
      * @return a {@link Mono} that indicates the initialization is done, or an error if the initialization failed.
      */
-    static Mono<Void> initHandshake(Client client, SslMode sslMode, String database, String user,
+    static Mono<Void> initHandshake(ReactorNettyClient client, SslMode sslMode, String database, String user,
         @Nullable CharSequence password, Set<CompressionAlgorithm> compressionAlgorithms, int zstdCompressionLevel) {
         return client.exchange(new HandshakeExchangeable(
             client,
@@ -488,7 +489,7 @@ final class HandshakeExchangeable extends FluxExchangeable<Void> {
     private final Sinks.Many<SubsequenceClientMessage> requests = Sinks.many().unicast()
         .onBackpressureBuffer(Queues.<SubsequenceClientMessage>one().get());
 
-    private final Client client;
+    private final ReactorNettyClient client;
 
     private final SslMode sslMode;
 
@@ -511,7 +512,7 @@ final class HandshakeExchangeable extends FluxExchangeable<Void> {
 
     private boolean sslCompleted;
 
-    HandshakeExchangeable(Client client, SslMode sslMode, String database, String user,
+    HandshakeExchangeable(ReactorNettyClient client, SslMode sslMode, String database, String user,
         @Nullable CharSequence password, Set<CompressionAlgorithm> compressions,
         int zstdCompressionLevel) {
         this.client = client;

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MultiHostsConnectionStrategy.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MultiHostsConnectionStrategy.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2024 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql;
+
+import io.asyncer.r2dbc.mysql.client.Client;
+import io.asyncer.r2dbc.mysql.constant.ProtocolDriver;
+import io.asyncer.r2dbc.mysql.internal.NodeAddress;
+import io.asyncer.r2dbc.mysql.internal.util.InternalArrays;
+import io.netty.channel.ChannelOption;
+import io.netty.resolver.DefaultNameResolver;
+import io.netty.resolver.NameResolver;
+import io.netty.util.concurrent.Future;
+import io.r2dbc.spi.R2dbcNonTransientResourceException;
+import org.jetbrains.annotations.Nullable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.netty.resources.LoopResources;
+import reactor.netty.tcp.TcpClient;
+import reactor.netty.tcp.TcpResources;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * An abstraction for {@link ConnectionStrategy} that consider multiple hosts.
+ */
+final class MultiHostsConnectionStrategy implements ConnectionStrategy {
+
+    private final Mono<Client> client;
+
+    MultiHostsConnectionStrategy(
+        TcpSocketConfiguration tcp,
+        MySqlConnectionConfiguration configuration,
+        boolean shuffle
+    ) {
+        this.client = Mono.defer(() -> {
+            if (ProtocolDriver.DNS_SRV.equals(tcp.getDriver())) {
+                LoopResources resources = configuration.getClient().getLoopResources();
+                LoopResources loopResources = resources == null ? TcpResources.get() : resources;
+
+                return resolveAllHosts(loopResources, tcp.getAddresses(), shuffle)
+                    .flatMap(addresses -> connectHost(addresses, tcp, configuration, false, shuffle, 0));
+            } else {
+                List<NodeAddress> availableHosts = copyAvailableAddresses(tcp.getAddresses(), shuffle);
+                int size = availableHosts.size();
+                InetSocketAddress[] addresses = new InetSocketAddress[availableHosts.size()];
+
+                for (int i = 0; i < size; i++) {
+                    NodeAddress address = availableHosts.get(i);
+                    addresses[i] = InetSocketAddress.createUnresolved(address.getHost(), address.getPort());
+                }
+
+                return connectHost(InternalArrays.asImmutableList(addresses), tcp, configuration, true, shuffle, 0);
+            }
+        });
+    }
+
+    @Override
+    public Mono<Client> connect() {
+        return client;
+    }
+
+    private Mono<Client> connectHost(
+        List<InetSocketAddress> addresses,
+        TcpSocketConfiguration tcp,
+        MySqlConnectionConfiguration configuration,
+        boolean balancedDns,
+        boolean shuffle,
+        int attempts
+    ) {
+        Iterator<InetSocketAddress> iter = addresses.iterator();
+
+        if (!iter.hasNext()) {
+            return Mono.error(fail("Fail to establish connection: no available host", null));
+        }
+
+        return configuration.getCredential().flatMap(credential -> attemptConnect(
+            iter.next(), credential, tcp, configuration, balancedDns
+        ).onErrorResume(t -> resumeConnect(
+            t, addresses, iter, credential, tcp, configuration, balancedDns, shuffle, attempts
+        )));
+    }
+
+    private Mono<Client> resumeConnect(
+        Throwable t,
+        List<InetSocketAddress> addresses,
+        Iterator<InetSocketAddress> iter,
+        Credential credential,
+        TcpSocketConfiguration tcp,
+        MySqlConnectionConfiguration configuration,
+        boolean balancedDns,
+        boolean shuffle,
+        int attempts
+    ) {
+        if (!iter.hasNext()) {
+            // The last host failed to connect
+            if (attempts >= tcp.getRetriesAllDown()) {
+                return Mono.error(fail(
+                    "Fail to establish connection, retried " + attempts + " times: " + t.getMessage(), t));
+            }
+
+            logger.warn("All hosts failed to establish connections, auto-try again after 250ms.");
+
+            // Ignore waiting error, e.g. interrupted, scheduler rejected
+            return Mono.delay(Duration.ofMillis(250))
+                .onErrorComplete()
+                .then(Mono.defer(() -> connectHost(addresses, tcp, configuration, balancedDns, shuffle, attempts + 1)));
+        }
+
+        return attemptConnect(iter.next(), credential, tcp, configuration, balancedDns).onErrorResume(tt ->
+            resumeConnect(tt, addresses, iter, credential, tcp, configuration, balancedDns, shuffle, attempts));
+    }
+
+    private Mono<Client> attemptConnect(
+        InetSocketAddress address,
+        Credential credential,
+        TcpSocketConfiguration tcp,
+        MySqlConnectionConfiguration configuration,
+        boolean balancedDns
+    ) {
+        TcpClient tcpClient = ConnectionStrategy.createTcpClient(configuration.getClient(), balancedDns)
+            .option(ChannelOption.SO_KEEPALIVE, tcp.isTcpKeepAlive())
+            .option(ChannelOption.TCP_NODELAY, tcp.isTcpNoDelay())
+            .remoteAddress(() -> address);
+
+        return ConnectionStrategy.connectWithInit(tcpClient, credential, configuration)
+            .doOnError(e -> logger.warn("Fail to connect: ", e));
+    }
+
+    private static Mono<List<InetSocketAddress>> resolveAllHosts(
+        LoopResources loopResources,
+        List<NodeAddress> addresses,
+        boolean shuffle
+    ) {
+        // Or DnsNameResolver? It is non-blocking but requires native dependencies, hard configurations, and maybe
+        // behaves differently. Currently, we use DefaultNameResolver which is blocking but simple and easy to use.
+        @SuppressWarnings("resource")
+        DefaultNameResolver resolver = new DefaultNameResolver(loopResources.onClient(true).next());
+
+        return Flux.fromIterable(addresses)
+            .flatMap(address -> resolveAll(resolver, address.getHost())
+                .flatMapIterable(Function.identity())
+                .map(inet -> new InetSocketAddress(inet, address.getPort())))
+            .doFinally(ignore -> resolver.close())
+            .collectList()
+            .map(list -> {
+                if (shuffle) {
+                    Collections.shuffle(list);
+                }
+
+                return list;
+            });
+    }
+
+    private static Mono<List<InetAddress>> resolveAll(NameResolver<InetAddress> resolver, String host) {
+        Future<List<InetAddress>> future = resolver.resolveAll(host);
+
+        return Mono.<List<InetAddress>>create(sink -> future.addListener(f -> {
+            if (f.isSuccess()) {
+                try {
+                    @SuppressWarnings("unchecked")
+                    List<InetAddress> t = (List<InetAddress>) f.getNow();
+
+                    logger.debug("Resolve {} in DNS succeed, {} records", host, t.size());
+                    sink.success(t);
+                } catch (Throwable e) {
+                    logger.warn("Resolve {} in DNS succeed but failed to get result", host, e);
+                    sink.success(Collections.emptyList());
+                }
+            } else {
+                logger.warn("Resolve {} in DNS failed", host, f.cause());
+                sink.success(Collections.emptyList());
+            }
+        })).doOnCancel(() -> future.cancel(false));
+    }
+
+    private static List<NodeAddress> copyAvailableAddresses(List<NodeAddress> addresses, boolean shuffle) {
+        if (shuffle) {
+            List<NodeAddress> copied = new ArrayList<>(addresses);
+            Collections.shuffle(copied);
+            return copied;
+        }
+
+        return InternalArrays.asImmutableList(addresses.toArray(new NodeAddress[0]));
+    }
+
+    private static R2dbcNonTransientResourceException fail(String message, @Nullable Throwable cause) {
+        return new R2dbcNonTransientResourceException(
+            message,
+            "H1000",
+            9000,
+            cause
+        );
+    }
+}

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MultiHostsConnectionStrategy.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MultiHostsConnectionStrategy.java
@@ -17,19 +17,17 @@
 package io.asyncer.r2dbc.mysql;
 
 import io.asyncer.r2dbc.mysql.client.Client;
+import io.asyncer.r2dbc.mysql.client.FailoverClient;
+import io.asyncer.r2dbc.mysql.client.ReactorNettyClient;
 import io.asyncer.r2dbc.mysql.constant.ProtocolDriver;
 import io.asyncer.r2dbc.mysql.internal.NodeAddress;
 import io.asyncer.r2dbc.mysql.internal.util.InternalArrays;
-import io.netty.channel.ChannelOption;
 import io.netty.resolver.DefaultNameResolver;
 import io.netty.resolver.NameResolver;
 import io.netty.util.concurrent.Future;
-import io.r2dbc.spi.R2dbcNonTransientResourceException;
-import org.jetbrains.annotations.Nullable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.netty.resources.LoopResources;
-import reactor.netty.tcp.TcpClient;
 import reactor.netty.tcp.TcpResources;
 
 import java.net.InetAddress;
@@ -46,105 +44,153 @@ import java.util.function.Function;
  */
 final class MultiHostsConnectionStrategy implements ConnectionStrategy {
 
-    private final Mono<Client> client;
+    private final Mono<? extends Client> client;
 
     MultiHostsConnectionStrategy(
-        TcpSocketConfiguration tcp,
         MySqlConnectionConfiguration configuration,
-        boolean shuffle
+        List<NodeAddress> addresses,
+        ProtocolDriver driver,
+        int retriesAllDown,
+        boolean shuffle,
+        boolean tcpKeepAlive,
+        boolean tcpNoDelay
     ) {
-        this.client = Mono.defer(() -> {
-            if (ProtocolDriver.DNS_SRV.equals(tcp.getDriver())) {
+        Mono<ReactorNettyClient> client = configuration.getCredential().flatMap(credential -> {
+            if (ProtocolDriver.DNS_SRV.equals(driver)) {
+                logger.debug("Resolve hosts via DNS SRV: {}", addresses);
+
                 LoopResources resources = configuration.getClient().getLoopResources();
                 LoopResources loopResources = resources == null ? TcpResources.get() : resources;
+                InetConnectFunction login = new InetConnectFunction(
+                    false,
+                    tcpKeepAlive,
+                    tcpNoDelay,
+                    credential,
+                    configuration
+                );
 
-                return resolveAllHosts(loopResources, tcp.getAddresses(), shuffle)
-                    .flatMap(addresses -> connectHost(addresses, tcp, configuration, false, shuffle, 0));
+                return resolveAllHosts(loopResources, addresses, shuffle).flatMap(addrs -> {
+                    logger.debug("Connect to multiple addresses: {}", addrs);
+
+                    return connectHost(
+                        addrs,
+                        login,
+                        shuffle,
+                        0,
+                        retriesAllDown
+                    );
+                });
             } else {
-                List<NodeAddress> availableHosts = copyAvailableAddresses(tcp.getAddresses(), shuffle);
+                List<NodeAddress> availableHosts = copyAvailableAddresses(addresses, shuffle);
+                logger.debug("Connect to multiple hosts: {}", availableHosts);
+
                 int size = availableHosts.size();
-                InetSocketAddress[] addresses = new InetSocketAddress[availableHosts.size()];
+                InetSocketAddress[] array = new InetSocketAddress[availableHosts.size()];
 
                 for (int i = 0; i < size; i++) {
-                    NodeAddress address = availableHosts.get(i);
-                    addresses[i] = InetSocketAddress.createUnresolved(address.getHost(), address.getPort());
+                    array[i] = availableHosts.get(i).toUnresolved();
                 }
 
-                return connectHost(InternalArrays.asImmutableList(addresses), tcp, configuration, true, shuffle, 0);
+                List<InetSocketAddress> addrs = InternalArrays.asImmutableList(array);
+                InetConnectFunction login = new InetConnectFunction(
+                    true,
+                    tcpKeepAlive,
+                    tcpNoDelay,
+                    credential,
+                    configuration
+                );
+
+                return connectHost(
+                    addrs,
+                    login,
+                    shuffle,
+                    0,
+                    retriesAllDown
+                );
             }
         });
+
+        this.client = client.map(c -> new FailoverClient(c, client));
     }
 
     @Override
-    public Mono<Client> connect() {
+    public Mono<? extends Client> connect() {
         return client;
     }
 
-    private Mono<Client> connectHost(
+    private static Mono<ReactorNettyClient> connectHost(
         List<InetSocketAddress> addresses,
-        TcpSocketConfiguration tcp,
-        MySqlConnectionConfiguration configuration,
-        boolean balancedDns,
+        InetConnectFunction login,
         boolean shuffle,
-        int attempts
+        int attempts,
+        int maxAttempts
     ) {
         Iterator<InetSocketAddress> iter = addresses.iterator();
 
         if (!iter.hasNext()) {
-            return Mono.error(fail("Fail to establish connection: no available host", null));
+            return Mono.error(ConnectionStrategy.retryFail("Fail to establish connection: no available host", null));
         }
 
-        return configuration.getCredential().flatMap(credential -> attemptConnect(
-            iter.next(), credential, tcp, configuration, balancedDns
-        ).onErrorResume(t -> resumeConnect(
-            t, addresses, iter, credential, tcp, configuration, balancedDns, shuffle, attempts
-        )));
+
+        InetSocketAddress address = iter.next();
+
+        return login.apply(() -> address).onErrorResume(error -> resumeConnect(
+            error,
+            address,
+            addresses,
+            iter,
+            login,
+            shuffle,
+            attempts,
+            maxAttempts
+        ));
     }
 
-    private Mono<Client> resumeConnect(
+    private static Mono<ReactorNettyClient> resumeConnect(
         Throwable t,
+        InetSocketAddress failed,
         List<InetSocketAddress> addresses,
         Iterator<InetSocketAddress> iter,
-        Credential credential,
-        TcpSocketConfiguration tcp,
-        MySqlConnectionConfiguration configuration,
-        boolean balancedDns,
+        InetConnectFunction login,
         boolean shuffle,
-        int attempts
+        int attempts,
+        int maxAttempts
     ) {
+        logger.warn("Fail to connect to {}", failed, t);
+
         if (!iter.hasNext()) {
             // The last host failed to connect
-            if (attempts >= tcp.getRetriesAllDown()) {
-                return Mono.error(fail(
-                    "Fail to establish connection, retried " + attempts + " times: " + t.getMessage(), t));
+            if (attempts >= maxAttempts) {
+                return Mono.error(ConnectionStrategy.retryFail(
+                    "Fail to establish connections, retried " + attempts + " times", t));
             }
 
-            logger.warn("All hosts failed to establish connections, auto-try again after 250ms.");
+            logger.warn("All hosts failed to establish connections, auto-try again after 250ms.", t);
 
             // Ignore waiting error, e.g. interrupted, scheduler rejected
             return Mono.delay(Duration.ofMillis(250))
                 .onErrorComplete()
-                .then(Mono.defer(() -> connectHost(addresses, tcp, configuration, balancedDns, shuffle, attempts + 1)));
+                .then(Mono.defer(() -> connectHost(
+                    addresses,
+                    login,
+                    shuffle,
+                    attempts + 1,
+                    maxAttempts
+                )));
         }
 
-        return attemptConnect(iter.next(), credential, tcp, configuration, balancedDns).onErrorResume(tt ->
-            resumeConnect(tt, addresses, iter, credential, tcp, configuration, balancedDns, shuffle, attempts));
-    }
+        InetSocketAddress address = iter.next();
 
-    private Mono<Client> attemptConnect(
-        InetSocketAddress address,
-        Credential credential,
-        TcpSocketConfiguration tcp,
-        MySqlConnectionConfiguration configuration,
-        boolean balancedDns
-    ) {
-        TcpClient tcpClient = ConnectionStrategy.createTcpClient(configuration.getClient(), balancedDns)
-            .option(ChannelOption.SO_KEEPALIVE, tcp.isTcpKeepAlive())
-            .option(ChannelOption.TCP_NODELAY, tcp.isTcpNoDelay())
-            .remoteAddress(() -> address);
-
-        return ConnectionStrategy.connectWithInit(tcpClient, credential, configuration)
-            .doOnError(e -> logger.warn("Fail to connect: ", e));
+        return login.apply(() -> address).onErrorResume(error -> resumeConnect(
+            error,
+            address,
+            addresses,
+            iter,
+            login,
+            shuffle,
+            attempts,
+            maxAttempts
+        ));
     }
 
     private static Mono<List<InetSocketAddress>> resolveAllHosts(
@@ -202,14 +248,5 @@ final class MultiHostsConnectionStrategy implements ConnectionStrategy {
         }
 
         return InternalArrays.asImmutableList(addresses.toArray(new NodeAddress[0]));
-    }
-
-    private static R2dbcNonTransientResourceException fail(String message, @Nullable Throwable cause) {
-        return new R2dbcNonTransientResourceException(
-            message,
-            "H1000",
-            9000,
-            cause
-        );
     }
 }

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlBatchingBatch.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlBatchingBatch.java
@@ -27,8 +27,8 @@ import java.util.StringJoiner;
 import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.requireNonNull;
 
 /**
- * An implementation of {@link MySqlBatch} for executing a collection of statements in a batch against the
- * MySQL database.
+ * An implementation of {@link MySqlBatch} for executing a collection of statements in a batch against the MySQL
+ * database.
  */
 final class MySqlBatchingBatch implements MySqlBatch {
 

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
@@ -67,6 +67,18 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
     public static final Option<String> UNIX_SOCKET = Option.valueOf("unixSocket");
 
     /**
+     * Option to whether to perform failover reconnection.  Default to {@code false}.
+     * <p>
+     * It is not recommended due to it may lead to unexpected results. For example, it may recover a transaction state
+     * from a failed server node to an available node, the user can not aware of it, and continuing to execute more
+     * queries in the transaction will lead to unexpected inconsistencies or errors. Or, user set a self-defined
+     * variable in the session, it may not be recovered to the new node due to the driver can not aware of it.
+     *
+     * @since 1.2.0
+     */
+    public static final Option<Boolean> AUTO_RECONNECT = Option.valueOf("autoReconnect");
+
+    /**
      * Option to set the time zone conversion.  Default to {@code true} means enable conversion between JVM and
      * {@link #CONNECTION_TIME_ZONE}.
      * <p>
@@ -361,6 +373,8 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
 
         mapper.optional(FORCE_CONNECTION_TIME_ZONE_TO_SESSION).asBoolean()
             .to(builder::forceConnectionTimeZoneToSession);
+        mapper.optional(AUTO_RECONNECT).asBoolean()
+            .to(builder::autoReconnect);
         mapper.optional(TCP_KEEP_ALIVE).asBoolean()
             .to(builder::tcpKeepAlive);
         mapper.optional(TCP_NO_DELAY).asBoolean()

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
@@ -17,8 +17,12 @@
 package io.asyncer.r2dbc.mysql;
 
 import io.asyncer.r2dbc.mysql.constant.CompressionAlgorithm;
+import io.asyncer.r2dbc.mysql.constant.ProtocolDriver;
+import io.asyncer.r2dbc.mysql.constant.HaProtocol;
 import io.asyncer.r2dbc.mysql.constant.SslMode;
 import io.asyncer.r2dbc.mysql.constant.ZeroDateOption;
+import io.asyncer.r2dbc.mysql.internal.NodeAddress;
+import io.asyncer.r2dbc.mysql.internal.util.AddressUtils;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
@@ -45,6 +49,7 @@ import static io.r2dbc.spi.ConnectionFactoryOptions.HOST;
 import static io.r2dbc.spi.ConnectionFactoryOptions.LOCK_WAIT_TIMEOUT;
 import static io.r2dbc.spi.ConnectionFactoryOptions.PASSWORD;
 import static io.r2dbc.spi.ConnectionFactoryOptions.PORT;
+import static io.r2dbc.spi.ConnectionFactoryOptions.PROTOCOL;
 import static io.r2dbc.spi.ConnectionFactoryOptions.SSL;
 import static io.r2dbc.spi.ConnectionFactoryOptions.STATEMENT_TIMEOUT;
 import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
@@ -55,11 +60,6 @@ import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
 public final class MySqlConnectionFactoryProvider implements ConnectionFactoryProvider {
 
     /**
-     * The name of the driver used for discovery, should not be changed.
-     */
-    public static final String MYSQL_DRIVER = "mysql";
-
-    /**
      * Option to set the Unix Domain Socket.
      *
      * @since 0.8.1
@@ -67,8 +67,8 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
     public static final Option<String> UNIX_SOCKET = Option.valueOf("unixSocket");
 
     /**
-     * Option to set the time zone conversion.  Default to {@code true} means enable conversion between JVM
-     * and {@link #CONNECTION_TIME_ZONE}.
+     * Option to set the time zone conversion.  Default to {@code true} means enable conversion between JVM and
+     * {@link #CONNECTION_TIME_ZONE}.
      * <p>
      * Note: disable it will ignore the time zone of connection, and use the JVM local time zone.
      *
@@ -77,9 +77,9 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
     public static final Option<Boolean> PRESERVE_INSTANTS = Option.valueOf("preserveInstants");
 
     /**
-     * Option to set the time zone of connection.  Default to {@code LOCAL} means use JVM local time zone.
-     * It should be {@code "LOCAL"}, {@code "SERVER"}, or a valid ID of {@code ZoneId}. {@code "SERVER"} means
-     * querying the server-side timezone during initialization.
+     * Option to set the time zone of connection.  Default to {@code LOCAL} means use JVM local time zone. It should be
+     * {@code "LOCAL"}, {@code "SERVER"}, or a valid ID of {@code ZoneId}. {@code "SERVER"} means querying the
+     * server-side timezone during initialization.
      *
      * @since 1.1.2
      */
@@ -88,8 +88,8 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
     /**
      * Option to force the time zone of connection to session time zone.  Default to {@code false}.
      * <p>
-     * Note: alter the time zone of session will affect the results of MySQL date/time functions, e.g.
-     * {@code NOW([n])}, {@code CURRENT_TIME([n])}, {@code CURRENT_DATE()}, etc. Please use with caution.
+     * Note: alter the time zone of session will affect the results of MySQL date/time functions, e.g. {@code NOW([n])},
+     * {@code CURRENT_TIME([n])}, {@code CURRENT_DATE()}, etc. Please use with caution.
      *
      * @since 1.1.2
      */
@@ -97,8 +97,7 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
         Option.valueOf("forceConnectionTimeZoneToSession");
 
     /**
-     * Option to set {@link ZoneId} of server. If it is set, driver will ignore the real time zone of
-     * server-side.
+     * Option to set {@link ZoneId} of server. If it is set, driver will ignore the real time zone of server-side.
      *
      * @since 0.8.2
      * @deprecated since 1.1.2, use {@link #CONNECTION_TIME_ZONE} instead.
@@ -122,8 +121,8 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
 
     /**
      * Option to configure {@link HostnameVerifier}. It is available only if the {@link #SSL_MODE} set to
-     * {@link SslMode#VERIFY_IDENTITY}. It can be an implementation class name of {@link HostnameVerifier}
-     * with a public no-args constructor.
+     * {@link SslMode#VERIFY_IDENTITY}. It can be an implementation class name of {@link HostnameVerifier} with a public
+     * no-args constructor.
      *
      * @since 0.8.2
      */
@@ -131,17 +130,17 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
         Option.valueOf("sslHostnameVerifier");
 
     /**
-     * Option to TLS versions for SslContext protocols, see also {@code TlsVersions}. Usually sorted from
-     * higher to lower. It can be a {@code Collection<String>}. It can be a {@link String}, protocols will be
-     * split by {@code ,}. e.g. "TLSv1.2,TLSv1.1,TLSv1".
+     * Option to TLS versions for SslContext protocols, see also {@code TlsVersions}. Usually sorted from higher to
+     * lower. It can be a {@code Collection<String>}. It can be a {@link String}, protocols will be split by {@code ,}.
+     * e.g. "TLSv1.2,TLSv1.1,TLSv1".
      *
      * @since 0.8.1
      */
     public static final Option<String[]> TLS_VERSION = Option.valueOf("tlsVersion");
 
     /**
-     * Option to set a PEM file of server SSL CA. It will be used to verify server certificates. And it will
-     * be used only if {@link #SSL_MODE} set to {@link SslMode#VERIFY_CA} or higher level.
+     * Option to set a PEM file of server SSL CA. It will be used to verify server certificates. And it will be used
+     * only if {@link #SSL_MODE} set to {@link SslMode#VERIFY_CA} or higher level.
      *
      * @since 0.8.1
      */
@@ -170,8 +169,8 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
     public static final Option<String> SSL_CERT = Option.valueOf("sslCert");
 
     /**
-     * Option to custom {@link SslContextBuilder}. It can be an implementation class name of {@link Function}
-     * with a public no-args constructor.
+     * Option to custom {@link SslContextBuilder}. It can be an implementation class name of {@link Function} with a
+     * public no-args constructor.
      *
      * @since 0.8.2
      */
@@ -203,18 +202,17 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
     /**
      * Enable server preparing for parameterized statements and prefer server preparing simple statements.
      * <p>
-     * The value can be a {@link Boolean}. If it is {@code true}, driver will use server preparing for
-     * parameterized statements and text query for simple statements. If it is {@code false}, driver will use
-     * client preparing for parameterized statements and text query for simple statements.
+     * The value can be a {@link Boolean}. If it is {@code true}, driver will use server preparing for parameterized
+     * statements and text query for simple statements. If it is {@code false}, driver will use client preparing for
+     * parameterized statements and text query for simple statements.
      * <p>
-     * The value can be a {@link Predicate}{@code <}{@link String}{@code >}. If it is set, driver will server
-     * preparing for parameterized statements, it configures whether to prefer prepare execution on a
-     * statement-by-statement basis (simple statements). The {@link Predicate}{@code <}{@link String}{@code >}
-     * accepts the simple SQL query string and returns a {@code boolean} flag indicating preference.
+     * The value can be a {@link Predicate}{@code <}{@link String}{@code >}. If it is set, driver will server preparing
+     * for parameterized statements, it configures whether to prefer prepare execution on a statement-by-statement basis
+     * (simple statements). The {@link Predicate}{@code <}{@link String}{@code >} accepts the simple SQL query string
+     * and returns a {@code boolean} flag indicating preference.
      * <p>
-     * The value can be a {@link String}. If it is set, driver will try to convert it to {@link Boolean} or an
-     * instance of {@link Predicate}{@code <}{@link String}{@code >} which use reflection with a public
-     * no-args constructor.
+     * The value can be a {@link String}. If it is set, driver will try to convert it to {@link Boolean} or an instance
+     * of {@link Predicate}{@code <}{@link String}{@code >} which use reflection with a public no-args constructor.
      *
      * @since 0.8.1
      */
@@ -248,9 +246,9 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
     /**
      * Option to set compression algorithms.  Default to [{@link CompressionAlgorithm#UNCOMPRESSED}].
      * <p>
-     * It will auto choose an algorithm that's contained in the list and supported by the server, preferring
-     * zstd, then zlib. If the list does not contain {@link CompressionAlgorithm#UNCOMPRESSED} and the server
-     * does not support any algorithm in the list, an exception will be thrown when connecting.
+     * It will auto choose an algorithm that's contained in the list and supported by the server, preferring zstd, then
+     * zlib. If the list does not contain {@link CompressionAlgorithm#UNCOMPRESSED} and the server does not support any
+     * algorithm in the list, an exception will be thrown when connecting.
      * <p>
      * Note: zstd requires a dependency {@code com.github.luben:zstd-jni}.
      *
@@ -264,8 +262,7 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
      * <p>
      * It is only used if zstd is chosen for the connection.
      * <p>
-     * Note: MySQL protocol does not allow to set the zlib compression level of the server, only zstd is
-     * configurable.
+     * Note: MySQL protocol does not allow to set the zlib compression level of the server, only zstd is configurable.
      *
      * @since 1.1.2
      */
@@ -302,9 +299,9 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
     public static final Option<Boolean> AUTODETECT_EXTENSIONS = Option.valueOf("autodetectExtensions");
 
     /**
-     * Password Publisher function can be used to retrieve password before creating a connection. This can be
-     * used with Amazon RDS Aurora IAM authentication, wherein it requires token to be generated. The token is
-     * valid for 15 minutes, and this token will be used as password.
+     * Password Publisher function can be used to retrieve password before creating a connection. This can be used with
+     * Amazon RDS Aurora IAM authentication, wherein it requires token to be generated. The token is valid for 15
+     * minutes, and this token will be used as password.
      */
     public static final Option<Publisher<String>> PASSWORD_PUBLISHER = Option.valueOf("passwordPublisher");
 
@@ -318,12 +315,14 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
     @Override
     public boolean supports(ConnectionFactoryOptions options) {
         requireNonNull(options, "connectionFactoryOptions must not be null");
-        return MYSQL_DRIVER.equals(options.getValue(DRIVER));
+
+        Object driver = options.getValue(DRIVER);
+        return driver instanceof String && ProtocolDriver.supports((String) driver);
     }
 
     @Override
     public String getDriver() {
-        return MYSQL_DRIVER;
+        return ProtocolDriver.standardDriver();
     }
 
     /**
@@ -340,16 +339,26 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
             .to(builder::user);
         mapper.optional(PASSWORD).asPassword()
             .to(builder::password);
-        mapper.optional(UNIX_SOCKET).asString()
-            .to(builder::unixSocket)
-            .otherwise(() -> setupHost(builder, mapper));
+
+        boolean unixSocket = mapper.optional(UNIX_SOCKET).asString()
+            .to(builder::unixSocket);
+
+        if (!unixSocket) {
+            setupHost(builder, mapper);
+        }
+
         mapper.optional(PRESERVE_INSTANTS).asBoolean()
             .to(builder::preserveInstants);
-        mapper.optional(CONNECTION_TIME_ZONE).asString()
-            .to(builder::connectionTimeZone)
-            .otherwise(() -> mapper.optional(SERVER_ZONE_ID)
+
+        boolean connectionTimeZone = mapper.optional(CONNECTION_TIME_ZONE).asString()
+            .to(builder::connectionTimeZone);
+
+        if (!connectionTimeZone) {
+            mapper.optional(SERVER_ZONE_ID)
                 .as(ZoneId.class, id -> ZoneId.of(id, ZoneId.SHORT_IDS))
-                .to(builder::serverZoneId));
+                .to(builder::serverZoneId);
+        }
+
         mapper.optional(FORCE_CONNECTION_TIME_ZONE_TO_SESSION).asBoolean()
             .to(builder::forceConnectionTimeZoneToSession);
         mapper.optional(TCP_KEEP_ALIVE).asBoolean()
@@ -388,7 +397,7 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
         mapper.optional(LOOP_RESOURCES).as(LoopResources.class)
             .to(builder::loopResources);
         mapper.optional(PASSWORD_PUBLISHER).as(Publisher.class)
-            .to(builder::passwordPublisher);
+            .to(builder::password);
         mapper.optional(SESSION_VARIABLES).asArray(
             String[].class,
             Function.identity(),
@@ -404,17 +413,44 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
     }
 
     /**
-     * Set builder of {@link MySqlConnectionConfiguration} for hostname-based address with SSL
-     * configurations.
+     * Set builder of {@link MySqlConnectionConfiguration} for hostname-based path with SSL configurations.
      *
      * @param builder the builder of {@link MySqlConnectionConfiguration}.
      * @param mapper  the {@link OptionMapper} of {@code options}.
      */
     private static void setupHost(MySqlConnectionConfiguration.Builder builder, OptionMapper mapper) {
-        mapper.requires(HOST).asString()
-            .to(builder::host);
-        mapper.optional(PORT).asInt()
+        boolean port = mapper.optional(PORT).asInt()
             .to(builder::port);
+
+        if (port) {
+            // If port is set, host must be a single host.
+            mapper.requires(HOST).asString()
+                .to(builder::host);
+        } else {
+            // If port is not set, host can be a single host or multiple hosts.
+            // If the URI contains an underscore in the host, it will produce an incorrectly resolved host and port.
+            // e.g. "r2dbc:mysql://my_db:3306" will be resolved to "my_db:3306" as host and null as port.
+            // See https://github.com/asyncer-io/r2dbc-mysql/issues/255
+            mapper.requires(HOST)
+                .asArray(String[].class, Function.identity(), it -> it.split(","), String[]::new)
+                .to(hosts -> {
+                    if (hosts.length == 1) {
+                        builder.host(hosts[0]);
+                        return;
+                    }
+
+                    for (String host : hosts) {
+                        NodeAddress address = AddressUtils.parseAddress(host);
+
+                        builder.addHost(address.getHost(), address.getPort());
+                    }
+                });
+        }
+
+        mapper.requires(DRIVER).as(ProtocolDriver.class, ProtocolDriver::from)
+            .to(builder::driver);
+        mapper.optional(PROTOCOL).as(HaProtocol.class, HaProtocol::from)
+            .to(builder::protocol);
         mapper.optional(SSL).asBoolean()
             .to(isSsl -> builder.sslMode(isSsl ? SslMode.REQUIRED : SslMode.DISABLED));
         mapper.optional(SSL_MODE).as(SslMode.class, id -> SslMode.valueOf(id.toUpperCase()))
@@ -437,12 +473,12 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
     }
 
     /**
-     * Splits session variables from user input. e.g. {@code sql_mode='ANSI_QUOTE,STRICT',c=d;e=f} will be
-     * split into {@code ["sql_mode='ANSI_QUOTE,STRICT'", "c=d", "e=f"]}.
+     * Splits session variables from user input. e.g. {@code sql_mode='ANSI_QUOTE,STRICT',c=d;e=f} will be split into
+     * {@code ["sql_mode='ANSI_QUOTE,STRICT'", "c=d", "e=f"]}.
      * <p>
-     * It supports escaping characters with backslash, quoted values with single or double quotes, and nested
-     * brackets. Priorities are: backslash in quoted &gt; single quote = double quote &gt; bracket, backslash
-     * will not be a valid escape character if it is not in a quoted value.
+     * It supports escaping characters with backslash, quoted values with single or double quotes, and nested brackets.
+     * Priorities are: backslash in quoted &gt; single quote = double quote &gt; bracket, backslash will not be a valid
+     * escape character if it is not in a quoted value.
      * <p>
      * Note that it does not strictly check syntax validity, so it will not throw syntax exceptions.
      *

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlStatementSupport.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlStatementSupport.java
@@ -46,12 +46,11 @@ abstract class MySqlStatementSupport implements MySqlStatement {
     public final MySqlStatement returnGeneratedValues(String... columns) {
         requireNonNull(columns, "columns must not be null");
 
-        ConnectionContext context = client.getContext();
         int len = columns.length;
 
         if (len == 0) {
             this.generatedColumns = InternalArrays.EMPTY_STRINGS;
-        } else if (len == 1 || supportReturning(context)) {
+        } else if (len == 1 || supportReturning(client.getContext())) {
             String[] result = new String[len];
 
             for (int i = 0; i < len; ++i) {
@@ -61,7 +60,7 @@ abstract class MySqlStatementSupport implements MySqlStatement {
 
             this.generatedColumns = result;
         } else {
-            String db = context.isMariaDb() ? "MariaDB 10.5.0 or below" : "MySQL";
+            String db = client.getContext().isMariaDb() ? "MariaDB 10.5.0 or below" : "MySQL";
             throw new IllegalArgumentException(db + " can have only one column");
         }
 

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/OptionMapper.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/OptionMapper.java
@@ -60,14 +60,13 @@ final class Source<T> {
         this.value = value;
     }
 
-    Otherwise to(Consumer<? super T> consumer) {
+    boolean to(Consumer<? super T> consumer) {
         if (value == null) {
-            return Otherwise.FALL;
+            return false;
         }
 
         consumer.accept(value);
-
-        return Otherwise.NOOP;
+        return true;
     }
 
     <R> Source<R> as(Class<R> type) {
@@ -267,28 +266,4 @@ final class Source<T> {
 
         return output;
     }
-}
-
-enum Otherwise {
-
-    NOOP {
-        @Override
-        void otherwise(Runnable runnable) {
-            // Do nothing
-        }
-    },
-
-    FALL {
-        @Override
-        void otherwise(Runnable runnable) {
-            runnable.run();
-        }
-    };
-
-    /**
-     * Invoked if the previous {@link Source} outcome did not match.
-     *
-     * @param runnable the {@link Runnable} that should be invoked.
-     */
-    abstract void otherwise(Runnable runnable);
 }

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/SingleHostConnectionStrategy.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/SingleHostConnectionStrategy.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql;
+
+import io.asyncer.r2dbc.mysql.client.Client;
+import io.asyncer.r2dbc.mysql.internal.NodeAddress;
+import io.netty.channel.ChannelOption;
+import reactor.core.publisher.Mono;
+import reactor.netty.tcp.TcpClient;
+
+/**
+ * An implementation of {@link ConnectionStrategy} that connects to a single host. It can be wrapped to a
+ * FailoverClient.
+ */
+final class SingleHostConnectionStrategy implements ConnectionStrategy {
+
+    private final Mono<Client> client;
+
+    SingleHostConnectionStrategy(TcpSocketConfiguration socket, MySqlConnectionConfiguration configuration) {
+        this.client = configuration.getCredential().flatMap(credential -> {
+            NodeAddress address = socket.getFirstAddress();
+
+            logger.debug("Connect to a single host: {}", address);
+
+            TcpClient tcpClient = ConnectionStrategy.createTcpClient(configuration.getClient(), true)
+                .option(ChannelOption.SO_KEEPALIVE, socket.isTcpKeepAlive())
+                .option(ChannelOption.TCP_NODELAY, socket.isTcpNoDelay())
+                .remoteAddress(address::toUnresolved);
+
+            return ConnectionStrategy.connectWithInit(tcpClient, credential, configuration);
+        });
+    }
+
+    @Override
+    public Mono<Client> connect() {
+        return client;
+    }
+}

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/SingleHostConnectionStrategy.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/SingleHostConnectionStrategy.java
@@ -17,10 +17,11 @@
 package io.asyncer.r2dbc.mysql;
 
 import io.asyncer.r2dbc.mysql.client.Client;
+import io.asyncer.r2dbc.mysql.client.ReactorNettyClient;
 import io.asyncer.r2dbc.mysql.internal.NodeAddress;
-import io.netty.channel.ChannelOption;
 import reactor.core.publisher.Mono;
-import reactor.netty.tcp.TcpClient;
+
+import java.time.Duration;
 
 /**
  * An implementation of {@link ConnectionStrategy} that connects to a single host. It can be wrapped to a
@@ -30,23 +31,66 @@ final class SingleHostConnectionStrategy implements ConnectionStrategy {
 
     private final Mono<Client> client;
 
-    SingleHostConnectionStrategy(TcpSocketConfiguration socket, MySqlConnectionConfiguration configuration) {
+    SingleHostConnectionStrategy(
+        MySqlConnectionConfiguration configuration,
+        NodeAddress address,
+        boolean tcpKeepAlive,
+        boolean tcpNoDelay
+    ) {
         this.client = configuration.getCredential().flatMap(credential -> {
-            NodeAddress address = socket.getFirstAddress();
-
             logger.debug("Connect to a single host: {}", address);
 
-            TcpClient tcpClient = ConnectionStrategy.createTcpClient(configuration.getClient(), true)
-                .option(ChannelOption.SO_KEEPALIVE, socket.isTcpKeepAlive())
-                .option(ChannelOption.TCP_NODELAY, socket.isTcpNoDelay())
-                .remoteAddress(address::toUnresolved);
+            InetConnectFunction login = new InetConnectFunction(
+                true,
+                tcpKeepAlive,
+                tcpNoDelay,
+                credential,
+                configuration
+            );
 
-            return ConnectionStrategy.connectWithInit(tcpClient, credential, configuration);
+            return connectHost(login, address, 0, 3);
         });
     }
 
     @Override
     public Mono<Client> connect() {
         return client;
+    }
+
+    private static Mono<ReactorNettyClient> connectHost(
+        InetConnectFunction login,
+        NodeAddress address,
+        int attempts,
+        int maxAttempts
+    ) {
+        return login.apply(address::toUnresolved)
+            .onErrorResume(t -> resumeConnect(t, address, login, attempts, maxAttempts));
+    }
+
+    private static Mono<ReactorNettyClient> resumeConnect(
+        Throwable t,
+        NodeAddress address,
+        InetConnectFunction login,
+        int attempts,
+        int maxAttempts
+    ) {
+        logger.warn("Fail to connect to {}", address, t);
+
+        if (attempts >= maxAttempts) {
+            return Mono.error(ConnectionStrategy.retryFail(
+                "Fail to establish connection, retried " + attempts + " times", t));
+        }
+
+        logger.warn("Failed to establish connection, auto-try again after 250ms.", t);
+
+        // Ignore waiting error, e.g. interrupted, scheduler rejected
+        return Mono.delay(Duration.ofMillis(250))
+            .onErrorComplete()
+            .then(Mono.defer(() -> connectHost(
+                login,
+                address,
+                attempts + 1,
+                maxAttempts
+            )));
     }
 }

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/SocketClientConfiguration.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/SocketClientConfiguration.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql;
+
+import org.jetbrains.annotations.Nullable;
+import reactor.netty.resources.LoopResources;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * A general-purpose configuration for a socket client. The client can be a TCP client or a Unix Domain Socket client.
+ */
+final class SocketClientConfiguration {
+
+    @Nullable
+    private final Duration connectTimeout;
+
+    @Nullable
+    private final LoopResources loopResources;
+
+    SocketClientConfiguration(@Nullable Duration connectTimeout, @Nullable LoopResources loopResources) {
+        this.connectTimeout = connectTimeout;
+        this.loopResources = loopResources;
+    }
+
+    @Nullable
+    Duration getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    @Nullable
+    LoopResources getLoopResources() {
+        return loopResources;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof SocketClientConfiguration)) {
+            return false;
+        }
+
+        SocketClientConfiguration that = (SocketClientConfiguration) o;
+
+        return Objects.equals(connectTimeout, that.connectTimeout) && Objects.equals(loopResources, that.loopResources);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * Objects.hashCode(connectTimeout) + Objects.hashCode(loopResources);
+    }
+
+    @Override
+    public String toString() {
+        return "Client{connectTimeout=" + connectTimeout + ", loopResources=" + loopResources + '}';
+    }
+
+    static final class Builder {
+
+        @Nullable
+        private Duration connectTimeout;
+
+        @Nullable
+        private LoopResources loopResources;
+
+        void connectTimeout(@Nullable Duration connectTimeout) {
+            this.connectTimeout = connectTimeout;
+        }
+
+        void loopResources(@Nullable LoopResources loopResources) {
+            this.loopResources = loopResources;
+        }
+
+        SocketClientConfiguration build() {
+            return new SocketClientConfiguration(connectTimeout, loopResources);
+        }
+    }
+}

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/SocketConfiguration.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/SocketConfiguration.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql;
+
+/**
+ * A sealed interface for socket configuration, it is also a factory for creating {@link ConnectionStrategy}.
+ *
+ * @see TcpSocketConfiguration
+ * @see UnixDomainSocketConfiguration
+ */
+interface SocketConfiguration {
+
+    ConnectionStrategy strategy(MySqlConnectionConfiguration configuration);
+}

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/TcpSocketConfiguration.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/TcpSocketConfiguration.java
@@ -219,16 +219,48 @@ final class TcpSocketConfiguration implements SocketConfiguration {
             case REPLICATION:
                 ConnectionStrategy.logger.warn(
                     "R2DBC Connection cannot be set to read-only, replication protocol will use the first host");
-                return new SingleHostConnectionStrategy(this, configuration);
+                return new MultiHostsConnectionStrategy(
+                    configuration,
+                    Collections.singletonList(getFirstAddress()),
+                    driver,
+                    retriesAllDown,
+                    false,
+                    tcpKeepAlive,
+                    tcpNoDelay
+                );
             case SEQUENTIAL:
-                return new MultiHostsConnectionStrategy(this, configuration, false);
+                return new MultiHostsConnectionStrategy(
+                    configuration,
+                    addresses,
+                    driver,
+                    retriesAllDown,
+                    false,
+                    tcpKeepAlive,
+                    tcpNoDelay
+                );
             case LOAD_BALANCE:
-                return new MultiHostsConnectionStrategy(this, configuration, true);
+                return new MultiHostsConnectionStrategy(
+                    configuration,
+                    addresses,
+                    driver,
+                    retriesAllDown,
+                    true,
+                    tcpKeepAlive,
+                    tcpNoDelay
+                );
             default:
                 if (ProtocolDriver.MYSQL == driver && addresses.size() == 1) {
-                    return new SingleHostConnectionStrategy(this, configuration);
+                    return new SingleHostConnectionStrategy(configuration, getFirstAddress(), tcpKeepAlive, tcpNoDelay);
                 } else {
-                    return new MultiHostsConnectionStrategy(this, configuration, false);
+                    return new MultiHostsConnectionStrategy(
+                        configuration,
+                        addresses,
+                        driver,
+                        retriesAllDown,
+                        false,
+                        tcpKeepAlive,
+                        tcpNoDelay
+                    );
                 }
         }
     }

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/TcpSocketConfiguration.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/TcpSocketConfiguration.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2024 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql;
+
+import io.asyncer.r2dbc.mysql.constant.HaProtocol;
+import io.asyncer.r2dbc.mysql.constant.ProtocolDriver;
+import io.asyncer.r2dbc.mysql.internal.NodeAddress;
+import io.asyncer.r2dbc.mysql.internal.util.InternalArrays;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.require;
+import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.requireNonEmpty;
+
+/**
+ * A configuration for a TCP/SSL socket.
+ */
+final class TcpSocketConfiguration implements SocketConfiguration {
+
+    private static final int DEFAULT_PORT = 3306;
+
+    private final ProtocolDriver driver;
+
+    private final HaProtocol protocol;
+
+    private final List<NodeAddress> addresses;
+
+    private final int retriesAllDown;
+
+    private final boolean tcpKeepAlive;
+
+    private final boolean tcpNoDelay;
+
+    TcpSocketConfiguration(
+        ProtocolDriver driver,
+        HaProtocol protocol,
+        List<NodeAddress> addresses,
+        int retriesAllDown,
+        boolean tcpKeepAlive,
+        boolean tcpNoDelay
+    ) {
+        this.driver = driver;
+        this.protocol = protocol;
+        this.addresses = addresses;
+        this.retriesAllDown = retriesAllDown;
+        this.tcpKeepAlive = tcpKeepAlive;
+        this.tcpNoDelay = tcpNoDelay;
+    }
+
+    ProtocolDriver getDriver() {
+        return driver;
+    }
+
+    HaProtocol getProtocol() {
+        return protocol;
+    }
+
+    NodeAddress getFirstAddress() {
+        if (addresses.isEmpty()) {
+            throw new IllegalStateException("No endpoints configured");
+        }
+        return addresses.get(0);
+    }
+
+    List<NodeAddress> getAddresses() {
+        return addresses;
+    }
+
+    int getRetriesAllDown() {
+        return retriesAllDown;
+    }
+
+    boolean isTcpKeepAlive() {
+        return tcpKeepAlive;
+    }
+
+    boolean isTcpNoDelay() {
+        return tcpNoDelay;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TcpSocketConfiguration)) {
+            return false;
+        }
+
+        TcpSocketConfiguration that = (TcpSocketConfiguration) o;
+
+        return tcpKeepAlive == that.tcpKeepAlive &&
+            tcpNoDelay == that.tcpNoDelay &&
+            driver == that.driver &&
+            protocol == that.protocol &&
+            retriesAllDown == that.retriesAllDown &&
+            addresses.equals(that.addresses);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = driver.hashCode();
+
+        result = 31 * result + protocol.hashCode();
+        result = 31 * result + addresses.hashCode();
+        result = 31 * result + retriesAllDown;
+        result = 31 * result + (tcpKeepAlive ? 1 : 0);
+
+        return 31 * result + (tcpNoDelay ? 1 : 0);
+    }
+
+    @Override
+    public String toString() {
+        return "TCP{driver=" + driver +
+            ", protocol=" + protocol +
+            ", addresses=" + addresses +
+            ", retriesAllDown=" + retriesAllDown +
+            ", tcpKeepAlive=" + tcpKeepAlive +
+            ", tcpNoDelay=" + tcpNoDelay +
+            '}';
+    }
+
+    static final class Builder {
+
+        private ProtocolDriver driver = ProtocolDriver.MYSQL;
+
+        private HaProtocol protocol = HaProtocol.DEFAULT;
+
+        private final List<NodeAddress> addresses = new ArrayList<>();
+
+        private String host = "";
+
+        private int port = DEFAULT_PORT;
+
+        private boolean tcpKeepAlive = false;
+
+        private boolean tcpNoDelay = true;
+
+        private int retriesAllDown = 10;
+
+        void driver(ProtocolDriver driver) {
+            this.driver = driver;
+        }
+
+        void protocol(HaProtocol protocol) {
+            this.protocol = protocol;
+        }
+
+        void host(String host) {
+            this.host = host;
+        }
+
+        void port(int port) {
+            this.port = port;
+        }
+
+        void addHost(String host, int port) {
+            this.addresses.add(new NodeAddress(host, port));
+        }
+
+        void addHost(String host) {
+            this.addresses.add(new NodeAddress(host));
+        }
+
+        void retriesAllDown(int retriesAllDown) {
+            this.retriesAllDown = retriesAllDown;
+        }
+
+        void tcpKeepAlive(boolean tcpKeepAlive) {
+            this.tcpKeepAlive = tcpKeepAlive;
+        }
+
+        void tcpNoDelay(boolean tcpNoDelay) {
+            this.tcpNoDelay = tcpNoDelay;
+        }
+
+        TcpSocketConfiguration build() {
+            List<NodeAddress> addresses;
+
+            if (this.addresses.isEmpty()) {
+                requireNonEmpty(host, "Either single host or multiple hosts must be configured");
+
+                addresses = Collections.singletonList(new NodeAddress(host, port));
+            } else {
+                require(host.isEmpty(), "Either single host or multiple hosts must be configured");
+
+                addresses = InternalArrays.asImmutableList(this.addresses.toArray(new NodeAddress[0]));
+            }
+
+            return new TcpSocketConfiguration(
+                driver,
+                protocol,
+                addresses,
+                retriesAllDown,
+                tcpKeepAlive,
+                tcpNoDelay);
+        }
+    }
+
+    @Override
+    public ConnectionStrategy strategy(MySqlConnectionConfiguration configuration) {
+        switch (protocol) {
+            case REPLICATION:
+                ConnectionStrategy.logger.warn(
+                    "R2DBC Connection cannot be set to read-only, replication protocol will use the first host");
+                return new SingleHostConnectionStrategy(this, configuration);
+            case SEQUENTIAL:
+                return new MultiHostsConnectionStrategy(this, configuration, false);
+            case LOAD_BALANCE:
+                return new MultiHostsConnectionStrategy(this, configuration, true);
+            default:
+                if (ProtocolDriver.MYSQL == driver && addresses.size() == 1) {
+                    return new SingleHostConnectionStrategy(this, configuration);
+                } else {
+                    return new MultiHostsConnectionStrategy(this, configuration, false);
+                }
+        }
+    }
+}

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/UnixDomainSocketConfiguration.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/UnixDomainSocketConfiguration.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql;
+
+/**
+ * A configuration for a Unix Domain Socket.
+ */
+final class UnixDomainSocketConfiguration implements SocketConfiguration {
+
+    private final String path;
+
+    UnixDomainSocketConfiguration(String path) {
+        this.path = path;
+    }
+
+    String getPath() {
+        return this.path;
+    }
+
+    @Override
+    public ConnectionStrategy strategy(MySqlConnectionConfiguration configuration) {
+        return new UnixDomainSocketConnectionStrategy(this, configuration);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof UnixDomainSocketConfiguration)) {
+            return false;
+        }
+
+        UnixDomainSocketConfiguration that = (UnixDomainSocketConfiguration) o;
+
+        return path.equals(that.path);
+    }
+
+    @Override
+    public int hashCode() {
+        return path.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "UnixDomainSocket{path='" + path + "'}";
+    }
+
+    static final class Builder {
+
+        private String path;
+
+        void path(String path) {
+            this.path = path;
+        }
+
+        UnixDomainSocketConfiguration build() {
+            return new UnixDomainSocketConfiguration(path);
+        }
+    }
+}

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/UnixDomainSocketConnectionStrategy.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/UnixDomainSocketConnectionStrategy.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql;
+
+import io.asyncer.r2dbc.mysql.client.Client;
+import io.netty.channel.unix.DomainSocketAddress;
+import reactor.core.publisher.Mono;
+import reactor.netty.tcp.TcpClient;
+
+/**
+ * An implementation of {@link ConnectionStrategy} that connects to a Unix Domain Socket.
+ */
+final class UnixDomainSocketConnectionStrategy implements ConnectionStrategy {
+
+    private final Mono<Client> client;
+
+    UnixDomainSocketConnectionStrategy(
+        UnixDomainSocketConfiguration socket,
+        MySqlConnectionConfiguration configuration
+    ) {
+        this.client = configuration.getCredential().flatMap(credential -> {
+            String path = socket.getPath();
+            TcpClient tcpClient = ConnectionStrategy.createTcpClient(configuration.getClient(), false)
+                .remoteAddress(() -> new DomainSocketAddress(path));
+
+            return ConnectionStrategy.connectWithInit(tcpClient, credential, configuration);
+        });
+    }
+
+    @Override
+    public Mono<Client> connect() {
+        return client;
+    }
+}

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/client/Client.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/client/Client.java
@@ -17,7 +17,6 @@
 package io.asyncer.r2dbc.mysql.client;
 
 import io.asyncer.r2dbc.mysql.ConnectionContext;
-import io.asyncer.r2dbc.mysql.MySqlSslConfiguration;
 import io.asyncer.r2dbc.mysql.message.client.ClientMessage;
 import io.asyncer.r2dbc.mysql.message.server.ServerMessage;
 import io.netty.buffer.ByteBufAllocator;
@@ -26,11 +25,8 @@ import io.netty.util.internal.logging.InternalLoggerFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.SynchronousSink;
-import reactor.netty.tcp.TcpClient;
 
 import java.util.function.BiConsumer;
-
-import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.requireNonNull;
 
 /**
  * An abstraction that wraps the networking part of exchanging methods.
@@ -99,31 +95,4 @@ public interface Client {
      * @return if connection is valid
      */
     boolean isConnected();
-
-    /**
-     * Sends a signal to the connection, which means server does not support SSL.
-     */
-    void sslUnsupported();
-
-    /**
-     * Sends a signal to {@link Client this}, which means login has succeeded.
-     */
-    void loginSuccess();
-
-    /**
-     * Connects to a MySQL server using the provided {@link TcpClient} and {@link MySqlSslConfiguration}.
-     *
-     * @param tcpClient the configured TCP client
-     * @param ssl       the SSL configuration
-     * @param context   the connection context
-     * @return A {@link Mono} that will emit a connected {@link Client}.
-     * @throws IllegalArgumentException if {@code tcpClient}, {@code ssl} or {@code context} is {@code null}.
-     */
-    static Mono<Client> connect(TcpClient tcpClient, MySqlSslConfiguration ssl, ConnectionContext context) {
-        requireNonNull(tcpClient, "tcpClient must not be null");
-        requireNonNull(ssl, "ssl must not be null");
-        requireNonNull(context, "context must not be null");
-
-        return tcpClient.connect().map(conn -> new ReactorNettyClient(conn, ssl, context));
-    }
 }

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/client/FailoverClient.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/client/FailoverClient.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql.client;
+
+import io.asyncer.r2dbc.mysql.ConnectionContext;
+import io.asyncer.r2dbc.mysql.message.client.ClientMessage;
+import io.asyncer.r2dbc.mysql.message.server.ServerMessage;
+import io.netty.buffer.ByteBufAllocator;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.SynchronousSink;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+
+/**
+ * An implementation of {@link Client} that supports failover.
+ */
+public final class FailoverClient implements Client {
+
+    private final Mono<ReactorNettyClient> failover;
+
+    private final AtomicReference<ReactorNettyClient> client;
+
+    public FailoverClient(ReactorNettyClient client, Mono<ReactorNettyClient> failover) {
+        this.client = new AtomicReference<>(client);
+        this.failover = failover;
+    }
+
+    private Mono<ReactorNettyClient> reconnectIfNecessary() {
+        return Mono.defer(() -> {
+            ReactorNettyClient client = this.client.get();
+
+            if (client.isChannelOpen() || client.isClosingOrClosed()) {
+                // Open, or closed by user
+                return Mono.just(client);
+            }
+
+            return this.failover.flatMap(c -> {
+                if (this.client.compareAndSet(client, c)) {
+                    // TODO: re-init session variables, transaction state, clear prepared cache, etc.
+                    return Mono.just(c);
+                }
+
+                // Reconnected by other thread, close this one and retry
+                return c.forceClose().then(reconnectIfNecessary());
+            });
+        });
+    }
+
+    @Override
+    public <T> Flux<T> exchange(ClientMessage request, BiConsumer<ServerMessage, SynchronousSink<T>> handler) {
+        return reconnectIfNecessary().flatMapMany(c -> c.exchange(request, handler));
+    }
+
+    @Override
+    public <T> Flux<T> exchange(FluxExchangeable<T> exchangeable) {
+        return reconnectIfNecessary().flatMapMany(c -> c.exchange(exchangeable));
+    }
+
+    @Override
+    public Mono<Void> close() {
+        return Mono.fromSupplier(this.client::get).flatMap(ReactorNettyClient::close);
+    }
+
+    @Override
+    public Mono<Void> forceClose() {
+        return Mono.fromSupplier(this.client::get).flatMap(ReactorNettyClient::forceClose);
+    }
+
+    @Override
+    public ByteBufAllocator getByteBufAllocator() {
+        return this.client.get().getByteBufAllocator();
+    }
+
+    @Override
+    public ConnectionContext getContext() {
+        return this.client.get().getContext();
+    }
+
+    @Override
+    public boolean isConnected() {
+        return this.client.get().isConnected();
+    }
+}

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/constant/HaProtocol.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/constant/HaProtocol.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2024 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql.constant;
+
+import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.requireNonNull;
+
+/**
+ * Failover and High-availability protocol.
+ * <p>
+ * The reconnect behavior is affected by the {@code autoReconnect} option.
+ */
+public enum HaProtocol {
+
+    /**
+     * Connecting: I want to connect sequentially until the first available node is found if multiple nodes are
+     * provided, otherwise connect to the single node.
+     * <p>
+     * Using: I want to get back to the first node if either {@code secondsBeforeRetryPrimaryHost} or
+     * {@code queriesBeforeRetryPrimaryHost} is set, and multiple nodes are provided.
+     * <p>
+     * Reconnect: I want to reconnect in the same order if the current node is not available and
+     * {@code autoReconnect=true}.
+     */
+    DEFAULT(""),
+
+    /**
+     * Connecting: I want to connect sequentially until the first available node is found.
+     * <p>
+     * Using: I want to keep using the current node until it is not available.
+     * <p>
+     * Reconnect: I want to reconnect in the same order if the current node is not available and
+     * {@code autoReconnect=true}.
+     */
+    SEQUENTIAL("sequential"),
+
+    /**
+     * Connecting: I want to connect in random order until the first available node is found.
+     * <p>
+     * Using: I want to keep using the current node until it is not available.
+     * <p>
+     * Reconnect: I want to re-randomize the order to reconnect if the current node is not available and
+     * {@code autoReconnect=true}.
+     */
+    LOAD_BALANCE("loadbalance"),
+
+    /**
+     * Connecting: I want to use read-write connection for the first node, and read-only connections for other nodes.
+     * <p>
+     * Using: I want to use the first node for read-write if connection is set to read-write, and other nodes if
+     * connection is set to read-only. R2DBC can not set a {@link io.r2dbc.spi.Connection Connection} to read-only mode.
+     * So it will always use the first host. R2DBC does not recommend this mutability. Perhaps in the future, R2DBC will
+     * support using read-only mode to create a connection instead of modifying an existing connection.
+     * <p>
+     * Reconnect: I want to reconnect to the current node if the current node is unavailable  and
+     * {@code autoReconnect=true}.
+     *
+     * @see <a href="https://github.com/r2dbc/r2dbc-spi/issues/98">Proposal: add Connection.setReadonly(boolean)</a>
+     */
+    REPLICATION("replication"),
+    ;
+
+    private final String name;
+
+    HaProtocol(String name) {
+        this.name = name;
+    }
+
+    public static HaProtocol from(String protocol) {
+        requireNonNull(protocol, "HA protocol must not be null");
+
+        for (HaProtocol haProtocol : HaProtocol.values()) {
+            if (haProtocol.name.equalsIgnoreCase(protocol)) {
+                return haProtocol;
+            }
+        }
+
+        throw new IllegalArgumentException("Unknown HA protocol: " + protocol);
+    }
+}

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/constant/HaProtocol.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/constant/HaProtocol.java
@@ -62,8 +62,8 @@ public enum HaProtocol {
      * <p>
      * Using: I want to use the first node for read-write if connection is set to read-write, and other nodes if
      * connection is set to read-only. R2DBC can not set a {@link io.r2dbc.spi.Connection Connection} to read-only mode.
-     * So it will always use the first host. R2DBC does not recommend this mutability. Perhaps in the future, R2DBC will
-     * support using read-only mode to create a connection instead of modifying an existing connection.
+     * So it will always use the first host. Perhaps in the future, R2DBC will support using read-only mode to create a
+     * connection instead of modifying an existing connection.
      * <p>
      * Reconnect: I want to reconnect to the current node if the current node is unavailable  and
      * {@code autoReconnect=true}.

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/constant/ProtocolDriver.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/constant/ProtocolDriver.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql.constant;
+
+import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.requireNonNull;
+
+/**
+ * Enumeration of driver connection schemes.
+ */
+public enum ProtocolDriver {
+
+    /**
+     * I want to use failover and high availability protocols for each host I set up. If I set a hostname that resolves
+     * to multiple IP addresses, the driver should pick one randomly.
+     * <p>
+     * Recommended in most cases. The hostname is resolved <b>when</b> high availability protocols are applied.
+     */
+    MYSQL,
+
+    /**
+     * I want to use failover and high availability protocols for each IP address. If I set a hostname that resolves to
+     * multiple IP addresses, the driver should flatten the list and try to connect to all of IP addresses.
+     * <p>
+     * The hostname is resolved <b>before</b> high availability protocols are applied.
+     */
+    DNS_SRV;
+
+    /**
+     * Default protocol driver name.
+     */
+    private static final String STANDARD_NAME = "mysql";
+
+    /**
+     * DNS SRV protocol driver name.
+     */
+    private static final String DNS_SRV_NAME = "mysql+srv";
+
+    public static String standardDriver() {
+        return STANDARD_NAME;
+    }
+
+    public static boolean supports(String driverName) {
+        requireNonNull(driverName, "driverName must not be null");
+
+        switch (driverName) {
+            case STANDARD_NAME:
+            case DNS_SRV_NAME:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public static ProtocolDriver from(String driverName) {
+        requireNonNull(driverName, "driverName must not be null");
+
+        switch (driverName) {
+            case STANDARD_NAME:
+                return MYSQL;
+            case DNS_SRV_NAME:
+                return DNS_SRV;
+            default:
+                throw new IllegalArgumentException("Unknown driver name: " + driverName);
+        }
+    }
+}

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/internal/NodeAddress.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/internal/NodeAddress.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql.internal;
+
+import java.net.InetSocketAddress;
+
+/**
+ * A value object representing a host and port. It will use the default port {@code 3306} if not specified.
+ */
+public final class NodeAddress {
+
+    private static final int DEFAULT_PORT = 3306;
+
+    private final String host;
+
+    private final int port;
+
+    public NodeAddress(String host) {
+        this(host, DEFAULT_PORT);
+    }
+
+    public NodeAddress(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public InetSocketAddress toUnresolved() {
+        return InetSocketAddress.createUnresolved(this.host, this.port);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof NodeAddress)) {
+            return false;
+        }
+
+        NodeAddress that = (NodeAddress) o;
+
+        return port == that.port && host.equals(that.host);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * host.hashCode() + port;
+    }
+
+    @Override
+    public String toString() {
+        return host + ":" + port;
+    }
+}

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/internal/util/InternalArrays.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/internal/util/InternalArrays.java
@@ -252,7 +252,7 @@ final class ArrList<E> extends AbstractList<E> implements List<E>, RandomAccess 
             return (T[]) Arrays.copyOf(source, source.length, a.getClass());
         }
 
-        System.arraycopy(source, 0, a, 0, this.a.length);
+        System.arraycopy(source, 0, a, 0, source.length);
 
         if (a.length > source.length) {
             a[source.length] = null;

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/HaProtocolIntegrationTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/HaProtocolIntegrationTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql;
+
+import io.asyncer.r2dbc.mysql.constant.HaProtocol;
+import io.asyncer.r2dbc.mysql.internal.util.TestContainerExtension;
+import io.asyncer.r2dbc.mysql.internal.util.TestServerUtil;
+import io.r2dbc.spi.ValidationDepth;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link HaProtocol}.
+ */
+@ExtendWith(TestContainerExtension.class)
+class HaProtocolIntegrationTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = { "sequential", "loadbalance" })
+    void anyAvailable(String protocol) {
+        MySqlConnectionFactory.from(configuration(HaProtocol.from(protocol), true)).create()
+            .flatMapMany(connection -> connection.validate(ValidationDepth.REMOTE)
+                .onErrorReturn(false)
+                .concatWith(connection.close().then(Mono.empty())))
+            .as(StepVerifier::create)
+            .expectNext(true)
+            .verifyComplete();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "replication", "" })
+    void firstAvailable(String protocol) {
+        MySqlConnectionFactory.from(configuration(HaProtocol.from(protocol), false)).create()
+            .flatMapMany(connection -> connection.validate(ValidationDepth.REMOTE)
+                .onErrorReturn(false)
+                .concatWith(connection.close().then(Mono.empty())))
+            .as(StepVerifier::create)
+            .expectNext(true)
+            .verifyComplete();
+    }
+
+    private MySqlConnectionConfiguration configuration(HaProtocol protocol, boolean badFirst) {
+        MySqlConnectionConfiguration.Builder builder = MySqlConnectionConfiguration.builder()
+            .protocol(protocol)
+            .connectTimeout(Duration.ofSeconds(3))
+            .user(TestServerUtil.getUsername())
+            .password(TestServerUtil.getPassword())
+            .database(TestServerUtil.getDatabase());
+
+        if (badFirst) {
+            builder.addHost(TestServerUtil.getHost(), 3310).addHost(TestServerUtil.getHost(), TestServerUtil.getPort());
+        } else {
+            builder.addHost(TestServerUtil.getHost(), TestServerUtil.getPort()).addHost(TestServerUtil.getHost(), 3310);
+        }
+
+        return builder.build();
+    }
+}

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfigurationTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfigurationTest.java
@@ -17,23 +17,29 @@
 package io.asyncer.r2dbc.mysql;
 
 import io.asyncer.r2dbc.mysql.constant.CompressionAlgorithm;
+import io.asyncer.r2dbc.mysql.constant.HaProtocol;
+import io.asyncer.r2dbc.mysql.constant.ProtocolDriver;
 import io.asyncer.r2dbc.mysql.constant.SslMode;
 import io.asyncer.r2dbc.mysql.constant.TlsVersions;
 import io.asyncer.r2dbc.mysql.constant.ZeroDateOption;
 import io.asyncer.r2dbc.mysql.extension.Extension;
+import io.asyncer.r2dbc.mysql.internal.NodeAddress;
 import io.netty.handler.ssl.SslContextBuilder;
-import org.assertj.core.api.ObjectAssert;
+import io.r2dbc.spi.ConnectionFactoryOptions;
 import org.assertj.core.api.ThrowableTypeAssert;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.time.Duration;
-import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -67,24 +73,20 @@ class MySqlConnectionConfigurationTest {
     @Test
     void unixSocket() {
         for (SslMode mode : SslMode.values()) {
-            if (mode.startSsl()) {
-                assertThatIllegalArgumentException().isThrownBy(() -> unixSocketSslMode(mode))
-                    .withMessageContaining("sslMode");
-            } else {
-                assertThat(unixSocketSslMode(SslMode.DISABLED)).isNotNull();
-            }
+            assertThat(unixSocketSslMode(mode)).isNotNull();
         }
 
         MySqlConnectionConfiguration configuration = MySqlConnectionConfiguration.builder()
             .unixSocket(UNIX_SOCKET)
             .user(USER)
             .build();
-        ObjectAssert<MySqlConnectionConfiguration> asserted = assertThat(configuration);
-        asserted.extracting(MySqlConnectionConfiguration::getDomain).isEqualTo(UNIX_SOCKET);
-        asserted.extracting(MySqlConnectionConfiguration::getUser).isEqualTo(USER);
-        asserted.extracting(MySqlConnectionConfiguration::isHost).isEqualTo(false);
-        asserted.extracting(MySqlConnectionConfiguration::getSsl)
-            .extracting(MySqlSslConfiguration::getSslMode).isEqualTo(SslMode.DISABLED);
+
+        assertThat(((UnixDomainSocketConfiguration) configuration.getSocket()).getPath()).isEqualTo(UNIX_SOCKET);
+        assertThat(configuration.getSsl().getSslMode()).isEqualTo(SslMode.DISABLED);
+        configuration.getCredential()
+            .as(StepVerifier::create)
+            .expectNext(new Credential(USER, null))
+            .verifyComplete();
     }
 
     @Test
@@ -93,12 +95,12 @@ class MySqlConnectionConfigurationTest {
             .host(HOST)
             .user(USER)
             .build();
-        ObjectAssert<MySqlConnectionConfiguration> asserted = assertThat(configuration);
-        asserted.extracting(MySqlConnectionConfiguration::getDomain).isEqualTo(HOST);
-        asserted.extracting(MySqlConnectionConfiguration::getUser).isEqualTo(USER);
-        asserted.extracting(MySqlConnectionConfiguration::isHost).isEqualTo(true);
-        asserted.extracting(MySqlConnectionConfiguration::getSsl)
-            .extracting(MySqlSslConfiguration::getSslMode).isEqualTo(SslMode.PREFERRED);
+        assertThat(((TcpSocketConfiguration) configuration.getSocket()).getAddresses())
+            .isEqualTo(Collections.singletonList(new NodeAddress(HOST)));
+        assertThat(configuration.getSsl().getSslMode()).isEqualTo(SslMode.PREFERRED);
+        configuration.getCredential().as(StepVerifier::create)
+            .expectNext(new Credential(USER, null))
+            .verifyComplete();
     }
 
     @Test
@@ -106,18 +108,20 @@ class MySqlConnectionConfigurationTest {
         String sslCa = "/path/to/ca.pem";
 
         for (SslMode mode : SslMode.values()) {
-            ObjectAssert<MySqlConnectionConfiguration> asserted = assertThat(hostedSslMode(mode, sslCa));
+            MySqlConnectionConfiguration configuration = hostedSslMode(mode, sslCa);
 
-            asserted.extracting(MySqlConnectionConfiguration::getDomain).isEqualTo(HOST);
-            asserted.extracting(MySqlConnectionConfiguration::getUser).isEqualTo(USER);
-            asserted.extracting(MySqlConnectionConfiguration::isHost).isEqualTo(true);
-            asserted.extracting(MySqlConnectionConfiguration::getSsl)
-                .extracting(MySqlSslConfiguration::getSslMode).isEqualTo(mode);
+            assertThat(configuration.getSsl().getSslMode()).isEqualTo(mode);
+            assertThat(((TcpSocketConfiguration) configuration.getSocket()).getAddresses())
+                .isEqualTo(Collections.singletonList(new NodeAddress(HOST)));
 
             if (mode.startSsl()) {
-                asserted.extracting(MySqlConnectionConfiguration::getSsl)
-                    .extracting(MySqlSslConfiguration::getSslCa).isSameAs(sslCa);
+                assertThat(configuration.getSsl().getSslCa()).isSameAs(sslCa);
             }
+
+            configuration.getCredential()
+                .as(StepVerifier::create)
+                .expectNext(new Credential(USER, null))
+                .verifyComplete();
         }
     }
 
@@ -131,13 +135,7 @@ class MySqlConnectionConfigurationTest {
 
     @Test
     void allFillUp() {
-        assertThat(filledUp()).extracting(MySqlConnectionConfiguration::getSsl).isNotNull();
-    }
-
-    @Test
-    void isEquals() {
-        assertThat(filledUp()).isEqualTo(filledUp()).extracting(Objects::hashCode)
-            .isEqualTo(filledUp().hashCode());
+        assertThat(filledUp().getSsl()).isNotNull();
     }
 
     @Test
@@ -194,17 +192,61 @@ class MySqlConnectionConfigurationTest {
 
     @Test
     void validPasswordSupplier() {
-        final Mono<String> passwordSupplier = Mono.just("123456");
+        Mono<String> passwordSupplier = Mono.just("123456");
+
         Mono.from(MySqlConnectionConfiguration.builder()
                 .host(HOST)
                 .user(USER)
                 .passwordPublisher(passwordSupplier)
                 .autodetectExtensions(false)
                 .build()
-                .getPasswordPublisher())
+                .getCredential())
             .as(StepVerifier::create)
-            .expectNext("123456")
+            .expectNext(new Credential(USER, "123456"))
             .verifyComplete();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "r2dbc:mysql://my-db1:3309,my-db2:3310/r2dbc",
+        "r2dbcs:mysql://my-db1:3309,my-db2:3310/r2dbc",
+        "r2dbc:mysql+srv://my-db1:3309,my-db2:3310/r2dbc",
+        "r2dbcs:mysql+srv://my-db1:3309,my-db2:3310/r2dbc",
+        "r2dbc:mysql:replication://my-db1:3309,my-db2:3310/r2dbc",
+        "r2dbcs:mysql:replication://my-db1:3309,my-db2:3310/r2dbc",
+        "r2dbc:mysql+srv:replication://my-db1:3309,my-db2:3310/r2dbc",
+        "r2dbcs:mysql+srv:replication://my-db1:3309,my-db2:3310/r2dbc",
+        "r2dbc:mysql:loadbalance://my-db1:3309,my-db2:3310/r2dbc",
+        "r2dbcs:mysql:loadbalance://my-db1:3309,my-db2:3310/r2dbc",
+        "r2dbc:mysql+srv:loadbalance://my-db1:3309,my-db2:3310/r2dbc",
+        "r2dbcs:mysql+srv:loadbalance://my-db1:3309,my-db2:3310/r2dbc",
+        "r2dbc:mysql:sequential://my-db1:3309,my-db2:3310/r2dbc",
+        "r2dbcs:mysql:sequential://my-db1:3309,my-db2:3310/r2dbc",
+        "r2dbc:mysql+srv:sequential://my-db1:3309,my-db2:3310/r2dbc",
+        "r2dbcs:mysql+srv:sequential://my-db1:3309,my-db2:3310/r2dbc",
+    })
+    void multipleHosts(String url) {
+        ConnectionFactoryOptions options = ConnectionFactoryOptions.parse(url)
+            .mutate()
+            .option(ConnectionFactoryOptions.USER, "root")
+            .build();
+        MySqlConnectionConfiguration configuration = MySqlConnectionFactoryProvider.setup(options);
+
+        assertThat(configuration.getSocket()).isInstanceOf(TcpSocketConfiguration.class);
+
+        TcpSocketConfiguration tcp = (TcpSocketConfiguration) configuration.getSocket();
+
+        assertThat(tcp.getAddresses()).isEqualTo(Arrays.asList(
+            new NodeAddress("my-db1", 3309),
+            new NodeAddress("my-db2", 3310)
+        ));
+        assertThat(tcp.getDriver()).isEqualTo(
+            ProtocolDriver.from(options.getRequiredValue(ConnectionFactoryOptions.DRIVER).toString()));
+        assertThat(tcp.getProtocol()).isEqualTo(
+            HaProtocol.from(Optional.ofNullable(options.getValue(ConnectionFactoryOptions.PROTOCOL))
+                .map(Object::toString)
+                .orElse(""))
+        );
     }
 
     private static MySqlConnectionConfiguration unixSocketSslMode(SslMode sslMode) {
@@ -225,6 +267,7 @@ class MySqlConnectionConfigurationTest {
     }
 
     private static MySqlConnectionConfiguration filledUp() {
+        // Since 1.0.5, the passwordPublisher is Mono, equals() and hashCode() are not reliable.
         return MySqlConnectionConfiguration.builder()
             .host(HOST)
             .user(USER)

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/MySqlSimpleConnectionTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/MySqlSimpleConnectionTest.java
@@ -37,8 +37,6 @@ import reactor.core.publisher.SynchronousSink;
 import reactor.test.StepVerifier;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/MySqlTestKitSupport.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/MySqlTestKitSupport.java
@@ -18,6 +18,7 @@ package io.asyncer.r2dbc.mysql;
 
 import com.zaxxer.hikari.HikariDataSource;
 import io.asyncer.r2dbc.mysql.internal.util.TestContainerExtension;
+import io.asyncer.r2dbc.mysql.internal.NodeAddress;
 import io.r2dbc.spi.test.TestKit;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -78,15 +79,19 @@ abstract class MySqlTestKitSupport implements TestKit<String> {
     }
 
     private static JdbcTemplate jdbc(MySqlConnectionConfiguration configuration) {
+        TcpSocketConfiguration socket = (TcpSocketConfiguration) configuration.getSocket();
+        NodeAddress address = socket.getFirstAddress();
+        Credential credential = configuration.getCredential().blockOptional().orElseThrow(() ->
+            new IllegalStateException("Credential must be present"));
         HikariDataSource source = new HikariDataSource();
 
-        source.setJdbcUrl(String.format("jdbc:mysql://%s:%d/%s", configuration.getDomain(),
-            configuration.getPort(), configuration.getDatabase()));
-        source.setUsername(configuration.getUser());
-        source.setPassword(Optional.ofNullable(configuration.getPassword())
+        source.setJdbcUrl(String.format("jdbc:mysql://%s:%d/%s",
+            address.getHost(), address.getPort(), configuration.getDatabase()));
+        source.setUsername(credential.getUser());
+        source.setPassword(Optional.ofNullable(credential.getPassword())
             .map(Object::toString).orElse(null));
         source.setMaximumPoolSize(1);
-        source.setConnectionTimeout(Optional.ofNullable(configuration.getConnectTimeout())
+        source.setConnectionTimeout(Optional.ofNullable(configuration.getClient().getConnectTimeout())
             .map(Duration::toMillis).orElse(0L));
 
         source.addDataSourceProperty("preserveInstants", configuration.isPreserveInstants());

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/OptionMapperTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/OptionMapperTest.java
@@ -92,12 +92,15 @@ class OptionMapperTest {
         AtomicReference<Object> ref = new AtomicReference<>(fill);
         AtomicReference<Object> other = new AtomicReference<>(fill);
 
-        new OptionMapper(ConnectionFactoryOptions.builder()
+        boolean set = new OptionMapper(ConnectionFactoryOptions.builder()
             .option(USER, "no-root")
             .build())
             .requires(USER)
-            .to(ref::set)
-            .otherwise(() -> other.set(8));
+            .to(ref::set);
+
+        if (!set) {
+            other.set(8);
+        }
 
         assertThat(ref.get()).isEqualTo("no-root");
         assertThat(other.get()).isSameAs(fill);
@@ -109,11 +112,14 @@ class OptionMapperTest {
         AtomicReference<Object> ref = new AtomicReference<>(fill);
         AtomicReference<Object> other = new AtomicReference<>(fill);
 
-        new OptionMapper(ConnectionFactoryOptions.builder()
+        boolean set = new OptionMapper(ConnectionFactoryOptions.builder()
             .build())
             .optional(USER)
-            .to(ref::set)
-            .otherwise(() -> other.set(8));
+            .to(ref::set);
+
+        if (!set) {
+            other.set(8);
+        }
 
         assertThat(ref.get()).isSameAs(fill);
         assertThat(other.get()).isEqualTo(8);

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/ProtocolDriverIntegrationTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/ProtocolDriverIntegrationTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql;
+
+import io.asyncer.r2dbc.mysql.internal.util.TestContainerExtension;
+import io.asyncer.r2dbc.mysql.internal.util.TestServerUtil;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import io.r2dbc.spi.ValidationDepth;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.time.Duration;
+
+/**
+ * Integration tests for DNS SRV records.
+ */
+@ExtendWith(TestContainerExtension.class)
+class ProtocolDriverIntegrationTest {
+
+    @Test
+    void anyAvailable() {
+        // Force to use localhost for DNS SRV testing
+        ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
+            .option(ConnectionFactoryOptions.DRIVER, "mysql+srv")
+            .option(ConnectionFactoryOptions.PROTOCOL, "loadbalance")
+            .option(ConnectionFactoryOptions.HOST, "localhost")
+            .option(ConnectionFactoryOptions.PORT, TestServerUtil.getPort())
+            .option(ConnectionFactoryOptions.USER, TestServerUtil.getUsername())
+            .option(ConnectionFactoryOptions.PASSWORD, TestServerUtil.getPassword())
+            .option(ConnectionFactoryOptions.CONNECT_TIMEOUT, Duration.ofSeconds(3))
+            .build();
+        // localhost should be resolved to 127.0.0.1 and [::1], but I can't make sure GitHub Actions support IPv6
+        MySqlConnectionFactory.from(MySqlConnectionFactoryProvider.setup(options))
+            .create()
+            .flatMapMany(connection -> connection.validate(ValidationDepth.REMOTE)
+                .onErrorReturn(false)
+                .concatWith(connection.close().then(Mono.empty())))
+            .as(StepVerifier::create)
+            .expectNext(true)
+            .verifyComplete();
+    }
+}

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/TimeZoneIntegrationTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/TimeZoneIntegrationTest.java
@@ -4,6 +4,7 @@ import com.zaxxer.hikari.HikariDataSource;
 import io.asyncer.r2dbc.mysql.api.MySqlResult;
 import io.asyncer.r2dbc.mysql.internal.util.TestContainerExtension;
 import io.asyncer.r2dbc.mysql.internal.util.TestServerUtil;
+import io.asyncer.r2dbc.mysql.internal.NodeAddress;
 import org.assertj.core.data.TemporalUnitOffset;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -306,22 +307,26 @@ class TimeZoneIntegrationTest {
         return customizer.apply(builder).build();
     }
 
-    private static JdbcTemplate jdbc(MySqlConnectionConfiguration config) {
+    private static JdbcTemplate jdbc(MySqlConnectionConfiguration configuration) {
+        TcpSocketConfiguration socket = (TcpSocketConfiguration) configuration.getSocket();
+        NodeAddress address = socket.getFirstAddress();
+        Credential credential = configuration.getCredential().blockOptional().orElseThrow(() ->
+            new IllegalStateException("Credential must be present"));
         HikariDataSource source = new HikariDataSource();
 
-        source.setJdbcUrl(String.format("jdbc:mysql://%s:%d/%s", config.getDomain(),
-            config.getPort(), config.getDatabase()));
-        source.setUsername(config.getUser());
-        source.setPassword(Optional.ofNullable(config.getPassword())
+        source.setJdbcUrl(String.format("jdbc:mysql://%s:%d/%s",
+            address.getHost(), address.getPort(), configuration.getDatabase()));
+        source.setUsername(credential.getUser());
+        source.setPassword(Optional.ofNullable(credential.getPassword())
             .map(Object::toString).orElse(null));
         source.setMaximumPoolSize(1);
-        source.setConnectionTimeout(Optional.ofNullable(config.getConnectTimeout())
+        source.setConnectionTimeout(Optional.ofNullable(configuration.getClient().getConnectTimeout())
             .map(Duration::toMillis).orElse(0L));
 
-        source.addDataSourceProperty("preserveInstants", config.isPreserveInstants());
-        source.addDataSourceProperty("connectionTimeZone", config.getConnectionTimeZone());
+        source.addDataSourceProperty("preserveInstants", configuration.isPreserveInstants());
+        source.addDataSourceProperty("connectionTimeZone", configuration.getConnectionTimeZone());
         source.addDataSourceProperty("forceConnectionTimeZoneToSession",
-            config.isForceConnectionTimeZoneToSession());
+            configuration.isForceConnectionTimeZoneToSession());
 
         return new JdbcTemplate(source);
     }

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/internal/util/AddressUtilsTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/internal/util/AddressUtilsTest.java
@@ -16,76 +16,180 @@
 
 package io.asyncer.r2dbc.mysql.internal.util;
 
-import org.junit.jupiter.api.Test;
+import io.asyncer.r2dbc.mysql.internal.NodeAddress;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit tests for {@link AddressUtils}.
  */
 class AddressUtilsTest {
 
-    @Test
-    void isIpv4() {
-        assertTrue(AddressUtils.isIpv4("1.0.0.0"));
-        assertTrue(AddressUtils.isIpv4("127.0.0.1"));
-        assertTrue(AddressUtils.isIpv4("10.11.12.13"));
-        assertTrue(AddressUtils.isIpv4("192.168.0.0"));
-        assertTrue(AddressUtils.isIpv4("255.255.255.255"));
-
-        assertFalse(AddressUtils.isIpv4("0.0.0.0"));
-        assertFalse(AddressUtils.isIpv4(" 127.0.0.1 "));
-        assertFalse(AddressUtils.isIpv4("01.11.12.13"));
-        assertFalse(AddressUtils.isIpv4("092.168.0.1"));
-        assertFalse(AddressUtils.isIpv4("055.255.255.255"));
-        assertFalse(AddressUtils.isIpv4("g.ar.ba.ge"));
-        assertFalse(AddressUtils.isIpv4("192.168.0"));
-        assertFalse(AddressUtils.isIpv4("192.168.0a.0"));
-        assertFalse(AddressUtils.isIpv4("256.255.255.255"));
-        assertFalse(AddressUtils.isIpv4("0.255.255.255"));
-
-        assertFalse(AddressUtils.isIpv4("::"));
-        assertFalse(AddressUtils.isIpv4("::1"));
-        assertFalse(AddressUtils.isIpv4("0:0:0:0:0:0:0:0"));
-        assertFalse(AddressUtils.isIpv4("0:0:0:0:0:0:0:1"));
-        assertFalse(AddressUtils.isIpv4("2001:0acd:0000:0000:0000:0000:3939:21fe"));
-        assertFalse(AddressUtils.isIpv4("2001:acd:0:0:0:0:3939:21fe"));
-        assertFalse(AddressUtils.isIpv4("2001:0acd:0:0::3939:21fe"));
-        assertFalse(AddressUtils.isIpv4("2001:0acd::3939:21fe"));
-        assertFalse(AddressUtils.isIpv4("2001:acd::3939:21fe"));
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "1.0.0.0",
+        "127.0.0.1",
+        "10.11.12.13",
+        "192.168.0.0",
+        "255.255.255.255",
+    })
+    void isIpv4(String address) {
+        assertThat(AddressUtils.isIpv4(address)).isTrue();
     }
 
-    @Test
-    void isIpv6() {
-        assertTrue(AddressUtils.isIpv6("::"));
-        assertTrue(AddressUtils.isIpv6("::1"));
-        assertTrue(AddressUtils.isIpv6("0:0:0:0:0:0:0:0"));
-        assertTrue(AddressUtils.isIpv6("0:0:0:0:0:0:0:1"));
-        assertTrue(AddressUtils.isIpv6("2001:0acd:0000:0000:0000:0000:3939:21fe"));
-        assertTrue(AddressUtils.isIpv6("2001:acd:0:0:0:0:3939:21fe"));
-        assertTrue(AddressUtils.isIpv6("2001:0acd:0:0::3939:21fe"));
-        assertTrue(AddressUtils.isIpv6("2001:0acd::3939:21fe"));
-        assertTrue(AddressUtils.isIpv6("2001:acd::3939:21fe"));
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "0.0.0.0",
+        " 127.0.0.1 ",
+        "01.11.12.13",
+        "092.168.0.1",
+        "055.255.255.255",
+        "g.ar.ba.ge",
+        "192.168.0",
+        "192.168.0a.0",
+        "256.255.255.255",
+        "0.255.255.255",
+        "::",
+        "::1",
+        "0:0:0:0:0:0:0:0",
+        "0:0:0:0:0:0:0:1",
+        "2001:0acd:0000:0000:0000:0000:3939:21fe",
+        "2001:acd:0:0:0:0:3939:21fe",
+        "2001:0acd:0:0::3939:21fe",
+        "2001:0acd::3939:21fe",
+        "2001:acd::3939:21fe",
+    })
+    void isNotIpv4(String address) {
+        assertThat(AddressUtils.isIpv4(address)).isFalse();
+    }
 
-        assertFalse(AddressUtils.isIpv6(""));
-        assertFalse(AddressUtils.isIpv6(":1"));
-        assertFalse(AddressUtils.isIpv6("0:0:0:0:0:0:0"));
-        assertFalse(AddressUtils.isIpv6("0:0:0:0:0:0:0:0:0"));
-        assertFalse(AddressUtils.isIpv6("2001:0acd:0000:garb:age0:0000:3939:21fe"));
-        assertFalse(AddressUtils.isIpv6("2001:0agd:0000:0000:0000:0000:3939:21fe"));
-        assertFalse(AddressUtils.isIpv6("2001:0acd::0000::21fe"));
-        assertFalse(AddressUtils.isIpv6("1:2:3:4:5:6:7::9"));
-        assertFalse(AddressUtils.isIpv6("1::3:4:5:6:7:8:9"));
-        assertFalse(AddressUtils.isIpv6("::3:4:5:6:7:8:9"));
-        assertFalse(AddressUtils.isIpv6("1:2::4:5:6:7:8:9"));
-        assertFalse(AddressUtils.isIpv6("1:2:3:4:5:6::8:9"));
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "::",
+        "::1",
+        "0:0:0:0:0:0:0:0",
+        "0:0:0:0:0:0:0:1",
+        "2001:0acd:0000:0000:0000:0000:3939:21fe",
+        "2001:acd:0:0:0:0:3939:21fe",
+        "2001:0acd:0:0::3939:21fe",
+        "2001:0acd::3939:21fe",
+        "2001:acd::3939:21fe",
+    })
+    void isIpv6(String address) {
+        assertThat(AddressUtils.isIpv6(address)).isTrue();
+    }
 
-        assertFalse(AddressUtils.isIpv6("0.0.0.0"));
-        assertFalse(AddressUtils.isIpv6("1.0.0.0"));
-        assertFalse(AddressUtils.isIpv6("127.0.0.1"));
-        assertFalse(AddressUtils.isIpv6("10.11.12.13"));
-        assertFalse(AddressUtils.isIpv6("192.168.0.0"));
-        assertFalse(AddressUtils.isIpv6("255.255.255.255"));
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "",
+        ":1",
+        "0:0:0:0:0:0:0",
+        "0:0:0:0:0:0:0:0:0",
+        "2001:0acd:0000:garb:age0:0000:3939:21fe",
+        "2001:0agd:0000:0000:0000:0000:3939:21fe",
+        "2001:0acd::0000::21fe",
+        "1:2:3:4:5:6:7::9",
+        "1::3:4:5:6:7:8:9",
+        "::3:4:5:6:7:8:9",
+        "1:2::4:5:6:7:8:9",
+        "1:2:3:4:5:6::8:9",
+        "0.0.0.0",
+        "1.0.0.0",
+        "127.0.0.1",
+        "10.11.12.13",
+        "192.168.0.0",
+        "255.255.255.255",
+    })
+    void isNotIpv6(String address) {
+        assertThat(AddressUtils.isIpv6(address)).isFalse();
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void parseAddress(String host, NodeAddress except) {
+        assertThat(AddressUtils.parseAddress(host)).isEqualTo(except);
+    }
+
+    static Stream<Arguments> parseAddress() {
+        return Stream.of(
+            Arguments.of("localhost", new NodeAddress("localhost")),
+            Arguments.of("localhost:", new NodeAddress("localhost:")),
+            Arguments.of("localhost:1", new NodeAddress("localhost", 1)),
+            Arguments.of("localhost:3307", new NodeAddress("localhost", 3307)),
+            Arguments.of("localhost:65535", new NodeAddress("localhost", 65535)),
+            Arguments.of("localhost:65536", new NodeAddress("localhost:65536")),
+            Arguments.of("localhost:165536", new NodeAddress("localhost:165536")),
+            Arguments.of("a1234", new NodeAddress("a1234")),
+            Arguments.of(":1234", new NodeAddress(":1234")),
+            Arguments.of("[]:3305", new NodeAddress("[]:3305")),
+            Arguments.of("[::1]", new NodeAddress("[::1]")),
+            Arguments.of("[::1]:2", new NodeAddress("[::1]", 2)),
+            Arguments.of("[::1]:567", new NodeAddress("[::1]", 567)),
+            Arguments.of("[::1]:65535", new NodeAddress("[::1]", 65535)),
+            Arguments.of("[::1]:65536", new NodeAddress("[::1]:65536")),
+            Arguments.of("[::]", new NodeAddress("[::]")),
+            Arguments.of("[1::]", new NodeAddress("[1::]")),
+            Arguments.of("[::]:3", new NodeAddress("[::]", 3)),
+            Arguments.of("[::]:65536", new NodeAddress("[::]:65536")),
+            Arguments.of(
+                "[2001::2:3307]",
+                new NodeAddress("[2001::2:3307]")
+            ),
+            Arguments.of(
+                "[2001::2]:3307",
+                new NodeAddress("[2001::2]", 3307)
+            ),
+            Arguments.of(
+                "[a772:8380:7adf:77fd:4d58:d629:a237:0b5e]",
+                new NodeAddress("[a772:8380:7adf:77fd:4d58:d629:a237:0b5e]")
+            ),
+            Arguments.of(
+                "[ff19:7c3d:8ddb:c86c:647b:17d6:b64a:7930]:4",
+                new NodeAddress("[ff19:7c3d:8ddb:c86c:647b:17d6:b64a:7930]", 4)
+            ),
+            Arguments.of(
+                "[1234:fd2:5621:1:89::45]:567",
+                new NodeAddress("[1234:fd2:5621:1:89::45]", 567)
+            ),
+            Arguments.of(
+                "[2001:470:26:12b:9a65:b818:6c96:4271]:65535",
+                new NodeAddress("[2001:470:26:12b:9a65:b818:6c96:4271]", 65535)
+            ),
+            Arguments.of("168.10.0.9", new NodeAddress("168.10.0.9")),
+            Arguments.of("168.10.0.9:5", new NodeAddress("168.10.0.9", 5)),
+            Arguments.of("168.10.0.9:1234", new NodeAddress("168.10.0.9", 1234)),
+            Arguments.of("168.10.0.9:65535", new NodeAddress("168.10.0.9", 65535)),
+            // See also https://github.com/asyncer-io/r2dbc-mysql/issues/255
+            Arguments.of("my_db", new NodeAddress("my_db")),
+            Arguments.of("my_db:6", new NodeAddress("my_db", 6)),
+            Arguments.of("my_db:3307", new NodeAddress("my_db", 3307)),
+            Arguments.of("my_db:65535", new NodeAddress("my_db", 65535)),
+            Arguments.of("db-service", new NodeAddress("db-service")),
+            Arguments.of("db-service:7", new NodeAddress("db-service", 7)),
+            Arguments.of("db-service:3307", new NodeAddress("db-service", 3307)),
+            Arguments.of("db-service:65535", new NodeAddress("db-service", 65535)),
+            Arguments.of(
+                "region_asia.rds3.some-cloud.com",
+                new NodeAddress("region_asia.rds3.some-cloud.com")
+            ),
+            Arguments.of(
+                "region_asia.rds4.some-cloud.com:8",
+                new NodeAddress("region_asia.rds4.some-cloud.com", 8)
+            ),
+            Arguments.of(
+                "region_asia.rds5.some-cloud.com:425",
+                new NodeAddress("region_asia.rds5.some-cloud.com", 425)
+            ),
+            Arguments.of(
+                "region_asia.rds6.some-cloud.com:65535",
+                new NodeAddress("region_asia.rds6.some-cloud.com", 65535)
+            )
+        );
     }
 }


### PR DESCRIPTION
Motivation:

Support for multiple hosts configuration.

Resolves #89 

It also resolves #255 because if the user uses multiple hosts we have to resolve the hostname and port ourselves

Modification:

- [x] Refactor `host`/`unixSocket` and add `addHost` to configure multiple hosts
- [x] Allow to use `Mono.zip` for user and password, because we have to receive and cache credential before we try to connect to multiple hosts
- [x] Add multiple hosts connection strategy
- [x] Add HA protocol support for multiple hosts
- [x] Allow to use DNS SRV records for HA protocol, like `r2dbc:mysql+srv:loadbalance://my-db-1,my-db-2/test`
- [ ] Add `autoReconnect`/`maxReconnects` support, `FailoverClient`
- [ ] Add failover events support and description
- [ ] Add reconnection strategy
- [ ] Add get back to primary host for default HA protocol, `queriesBeforeRetrySource` and `secondsBeforeRetrySource`

User can only configure one of:

- `host`/`port` for a single host
- `addHost` for multiple hosts, it will be auto-converted from `ConnectionFactoryOptions.HOST`
- `unixSocket` for Unix Domain Socket.

Result:

Support multiple hosts configuration with HA protocol.

Support DNS SRV Records for HA protocol.