### PR TITLE
Reduce retained references to ConnectionContext

### DIFF
--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/Capability.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/Capability.java
@@ -177,6 +177,11 @@ public final class Capability {
         TRANSACTIONS | SECURE_SALT | MULTI_STATEMENTS | MULTI_RESULTS | PS_MULTI_RESULTS |
         PLUGIN_AUTH | CONNECT_ATTRS | VAR_INT_SIZED_AUTH | SESSION_TRACK | DEPRECATE_EOF | ZSTD_COMPRESS;
 
+    /**
+     * The default capabilities for a MySQL connection. It contains all client supported capabilities.
+     */
+    public static final Capability DEFAULT = new Capability(ALL_SUPPORTED);
+
     private final long bitmap;
 
     /**
@@ -373,7 +378,8 @@ public final class Capability {
      * @return the {@link Capability} without unknown flags.
      */
     public static Capability of(long capabilities) {
-        return new Capability(capabilities & ALL_SUPPORTED);
+        long c = capabilities & ALL_SUPPORTED;
+        return c == ALL_SUPPORTED ? DEFAULT : new Capability(c);
     }
 
     static final class Builder {

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlBatchingBatch.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlBatchingBatch.java
@@ -36,14 +36,11 @@ final class MySqlBatchingBatch implements MySqlBatch {
 
     private final Codecs codecs;
 
-    private final ConnectionContext context;
-
     private final StringJoiner queries = new StringJoiner(";");
 
-    MySqlBatchingBatch(Client client, Codecs codecs, ConnectionContext context) {
+    MySqlBatchingBatch(Client client, Codecs codecs) {
         this.client = requireNonNull(client, "client must not be null");
         this.codecs = requireNonNull(codecs, "codecs must not be null");
-        this.context = requireNonNull(context, "context must not be null");
     }
 
     @Override
@@ -65,7 +62,7 @@ final class MySqlBatchingBatch implements MySqlBatch {
     @Override
     public Flux<MySqlResult> execute() {
         return QueryFlow.execute(client, getSql())
-            .map(messages -> MySqlSegmentResult.toResult(false, codecs, context, null, messages));
+            .map(messages -> MySqlSegmentResult.toResult(false, client, codecs, null, messages));
     }
 
     @Override

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactory.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactory.java
@@ -151,7 +151,7 @@ public final class MySqlConnectionFactory implements ConnectionFactory {
             final String user,
             final SslMode sslMode,
             final Set<CompressionAlgorithm> compressionAlgorithms,
-            final int zstdCompressionLevel,
+            final int zstdLevel,
             final ConnectionContext context,
             final Extensions extensions,
             final List<String> sessionVariables,
@@ -163,8 +163,7 @@ public final class MySqlConnectionFactory implements ConnectionFactory {
             .flatMap(client -> {
                 // Lazy init database after handshake/login
                 String db = createDbIfNotExist ? "" : database;
-                return QueryFlow.login(client, sslMode, db, user, password, compressionAlgorithms,
-                    zstdCompressionLevel, context);
+                return QueryFlow.login(client, sslMode, db, user, password, compressionAlgorithms, zstdLevel);
             })
             .flatMap(client -> {
                 ByteBufAllocator allocator = client.getByteBufAllocator();
@@ -175,7 +174,7 @@ public final class MySqlConnectionFactory implements ConnectionFactory {
                 extensions.forEach(CodecRegistrar.class, registrar ->
                     registrar.register(allocator, builder));
 
-                return MySqlSimpleConnection.init(client, builder.build(), context, db, queryCache.get(),
+                return MySqlSimpleConnection.init(client, builder.build(), db, queryCache.get(),
                     prepareCache, sessionVariables, prepare);
             });
     }

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlDataRow.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlDataRow.java
@@ -18,6 +18,7 @@ package io.asyncer.r2dbc.mysql;
 
 import io.asyncer.r2dbc.mysql.api.MySqlRow;
 import io.asyncer.r2dbc.mysql.api.MySqlRowMetadata;
+import io.asyncer.r2dbc.mysql.codec.CodecContext;
 import io.asyncer.r2dbc.mysql.codec.Codecs;
 import io.asyncer.r2dbc.mysql.message.FieldValue;
 import io.r2dbc.spi.Row;
@@ -42,10 +43,13 @@ final class MySqlDataRow implements MySqlRow {
      */
     private final boolean binary;
 
-    private final ConnectionContext context;
+    /**
+     * It can be retained because it is provided by the executed connection instead of the current connection.
+     */
+    private final CodecContext context;
 
     MySqlDataRow(FieldValue[] fields, MySqlRowDescriptor rowMetadata, Codecs codecs, boolean binary,
-        ConnectionContext context) {
+        CodecContext context) {
         this.fields = requireNonNull(fields, "fields must not be null");
         this.rowMetadata = requireNonNull(rowMetadata, "rowMetadata must not be null");
         this.codecs = requireNonNull(codecs, "codecs must not be null");

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlSyntheticBatch.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlSyntheticBatch.java
@@ -37,14 +37,11 @@ final class MySqlSyntheticBatch implements MySqlBatch {
 
     private final Codecs codecs;
 
-    private final ConnectionContext context;
-
     private final List<String> statements = new ArrayList<>();
 
-    MySqlSyntheticBatch(Client client, Codecs codecs, ConnectionContext context) {
+    MySqlSyntheticBatch(Client client, Codecs codecs) {
         this.client = requireNonNull(client, "client must not be null");
         this.codecs = requireNonNull(codecs, "codecs must not be null");
-        this.context = requireNonNull(context, "context must not be null");
     }
 
     @Override
@@ -56,7 +53,7 @@ final class MySqlSyntheticBatch implements MySqlBatch {
     @Override
     public Flux<MySqlResult> execute() {
         return QueryFlow.execute(client, statements)
-            .map(messages -> MySqlSegmentResult.toResult(false, codecs, context, null, messages));
+            .map(messages -> MySqlSegmentResult.toResult(false, client, codecs, null, messages));
     }
 
     @Override

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/ParametrizedStatementSupport.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/ParametrizedStatementSupport.java
@@ -41,8 +41,6 @@ import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.requireNonNull;
  */
 abstract class ParametrizedStatementSupport extends MySqlStatementSupport {
 
-    protected final Client client;
-
     protected final Codecs codecs;
 
     protected final Query query;
@@ -51,13 +49,12 @@ abstract class ParametrizedStatementSupport extends MySqlStatementSupport {
 
     private final AtomicBoolean executed = new AtomicBoolean();
 
-    ParametrizedStatementSupport(Client client, Codecs codecs, Query query, ConnectionContext context) {
-        super(context);
+    ParametrizedStatementSupport(Client client, Codecs codecs, Query query) {
+        super(client);
 
         requireNonNull(query, "query must not be null");
         require(query.getParameters() > 0, "parameters must be a positive integer");
 
-        this.client = requireNonNull(client, "client must not be null");
         this.codecs = requireNonNull(codecs, "codecs must not be null");
         this.query = query;
         this.bindings = new Bindings(query.getParameters());
@@ -75,7 +72,7 @@ abstract class ParametrizedStatementSupport extends MySqlStatementSupport {
     public final MySqlStatement bind(int index, Object value) {
         requireNonNull(value, "value must not be null");
 
-        addBinding(index, codecs.encode(value, context));
+        addBinding(index, codecs.encode(value, client.getContext()));
         return this;
     }
 
@@ -84,7 +81,7 @@ abstract class ParametrizedStatementSupport extends MySqlStatementSupport {
         requireNonNull(name, "name must not be null");
         requireNonNull(value, "value must not be null");
 
-        addBinding(getIndexes(name), codecs.encode(value, context));
+        addBinding(getIndexes(name), codecs.encode(value, client.getContext()));
         return this;
     }
 

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/PrepareParametrizedStatement.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/PrepareParametrizedStatement.java
@@ -37,9 +37,8 @@ final class PrepareParametrizedStatement extends ParametrizedStatementSupport {
 
     private int fetchSize = 0;
 
-    PrepareParametrizedStatement(Client client, Codecs codecs, Query query, ConnectionContext context,
-        PrepareCache prepareCache) {
-        super(client, codecs, query, context);
+    PrepareParametrizedStatement(Client client, Codecs codecs, Query query, PrepareCache prepareCache) {
+        super(client, codecs, query);
         this.prepareCache = prepareCache;
     }
 
@@ -49,7 +48,7 @@ final class PrepareParametrizedStatement extends ParametrizedStatementSupport {
                 StringUtils.extendReturning(query.getFormattedSql(), returningIdentifiers()),
                 bindings, fetchSize, prepareCache
             ))
-            .map(messages -> MySqlSegmentResult.toResult(true, codecs, context, syntheticKeyName(), messages));
+            .map(messages -> MySqlSegmentResult.toResult(true, client, codecs, syntheticKeyName(), messages));
     }
 
     @Override

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/PrepareSimpleStatement.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/PrepareSimpleStatement.java
@@ -40,9 +40,8 @@ final class PrepareSimpleStatement extends SimpleStatementSupport {
 
     private int fetchSize = 0;
 
-    PrepareSimpleStatement(Client client, Codecs codecs, ConnectionContext context, String sql,
-        PrepareCache prepareCache) {
-        super(client, codecs, context, sql);
+    PrepareSimpleStatement(Client client, Codecs codecs, String sql, PrepareCache prepareCache) {
+        super(client, codecs, sql);
         this.prepareCache = prepareCache;
     }
 
@@ -50,7 +49,7 @@ final class PrepareSimpleStatement extends SimpleStatementSupport {
     public Flux<MySqlResult> execute() {
         return Flux.defer(() -> QueryFlow.execute(client,
                 StringUtils.extendReturning(sql, returningIdentifiers()), BINDINGS, fetchSize, prepareCache))
-            .map(messages -> MySqlSegmentResult.toResult(true, codecs, context, syntheticKeyName(), messages));
+            .map(messages -> MySqlSegmentResult.toResult(true, client, codecs, syntheticKeyName(), messages));
     }
 
     @Override

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/SimpleStatementSupport.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/SimpleStatementSupport.java
@@ -27,16 +27,13 @@ import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.requireNonNull;
  */
 abstract class SimpleStatementSupport extends MySqlStatementSupport {
 
-    protected final Client client;
-
     protected final Codecs codecs;
 
     protected final String sql;
 
-    SimpleStatementSupport(Client client, Codecs codecs, ConnectionContext context, String sql) {
-        super(context);
+    SimpleStatementSupport(Client client, Codecs codecs, String sql) {
+        super(client);
 
-        this.client = requireNonNull(client, "client must not be null");
         this.codecs = requireNonNull(codecs, "codecs must not be null");
         this.sql = requireNonNull(sql, "sql must not be null");
     }

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/TextParametrizedStatement.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/TextParametrizedStatement.java
@@ -28,14 +28,13 @@ import java.util.List;
  */
 final class TextParametrizedStatement extends ParametrizedStatementSupport {
 
-    TextParametrizedStatement(Client client, Codecs codecs, Query query, ConnectionContext context) {
-        super(client, codecs, query, context);
+    TextParametrizedStatement(Client client, Codecs codecs, Query query) {
+        super(client, codecs, query);
     }
 
     @Override
     protected Flux<MySqlResult> execute(List<Binding> bindings) {
-        return Flux.defer(() -> QueryFlow.execute(client, query, returningIdentifiers(),
-                bindings))
-            .map(messages -> MySqlSegmentResult.toResult(false, codecs, context, syntheticKeyName(), messages));
+        return Flux.defer(() -> QueryFlow.execute(client, query, returningIdentifiers(), bindings))
+            .map(messages -> MySqlSegmentResult.toResult(false, client, codecs, syntheticKeyName(), messages));
     }
 }

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/TextSimpleStatement.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/TextSimpleStatement.java
@@ -27,8 +27,8 @@ import reactor.core.publisher.Flux;
  */
 final class TextSimpleStatement extends SimpleStatementSupport {
 
-    TextSimpleStatement(Client client, Codecs codecs, ConnectionContext context, String sql) {
-        super(client, codecs, context, sql);
+    TextSimpleStatement(Client client, Codecs codecs, String sql) {
+        super(client, codecs, sql);
     }
 
     @Override
@@ -36,6 +36,6 @@ final class TextSimpleStatement extends SimpleStatementSupport {
         return Flux.defer(() -> QueryFlow.execute(
             client,
             StringUtils.extendReturning(sql, returningIdentifiers())
-        ).map(messages -> MySqlSegmentResult.toResult(false, codecs, context, syntheticKeyName(), messages)));
+        ).map(messages -> MySqlSegmentResult.toResult(false, client, codecs, syntheticKeyName(), messages)));
     }
 }

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/client/Client.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/client/Client.java
@@ -46,21 +46,21 @@ public interface Client {
     InternalLogger logger = InternalLoggerFactory.getInstance(Client.class);
 
     /**
-     * Perform an exchange of a request message. Calling this method while a previous exchange is active will
-     * return a deferred handle and queue the request until the previous exchange terminates.
+     * Perform an exchange of a request message. Calling this method while a previous exchange is active will return a
+     * deferred handle and queue the request until the previous exchange terminates.
      *
      * @param request one and only one request message for get server responses
-     * @param handler response handler, {@link SynchronousSink#complete()} should be called after the last
-     *                response frame is sent to complete the stream and prevent multiple subscribers from
-     *                consuming previous, active response streams
+     * @param handler response handler, {@link SynchronousSink#complete()} should be called after the last response
+     *                frame is sent to complete the stream and prevent multiple subscribers from consuming previous,
+     *                active response streams
      * @param <T>     handling response type
      * @return A {@link Flux} of incoming messages that ends with the end of the frame
      */
     <T> Flux<T> exchange(ClientMessage request, BiConsumer<ServerMessage, SynchronousSink<T>> handler);
 
     /**
-     * Perform an exchange of multi-request messages. Calling this method while a previous exchange is active
-     * will return a deferred handle and queue the request until the previous exchange terminates.
+     * Perform an exchange of multi-request messages. Calling this method while a previous exchange is active will
+     * return a deferred handle and queue the request until the previous exchange terminates.
      *
      * @param exchangeable request messages and response handler
      * @param <T>          handling response type
@@ -92,6 +92,14 @@ public interface Client {
     ByteBufAllocator getByteBufAllocator();
 
     /**
+     * Returns the current {@link ConnectionContext}. It should not be retained long-term as it may change on reconnects
+     * or redirects.
+     *
+     * @return the {@link ConnectionContext}
+     */
+    ConnectionContext getContext();
+
+    /**
      * Checks if the connection is open.
      *
      * @return if connection is valid
@@ -117,20 +125,20 @@ public interface Client {
      * @param tcpNoDelay     if enable the {@link ChannelOption#TCP_NODELAY}
      * @param context        the connection context
      * @param connectTimeout connect timeout, or {@code null} if it has no timeout
-     * @param loopResources the loop resources to use
+     * @param loopResources  the loop resources to use
      * @return A {@link Mono} that will emit a connected {@link Client}.
      * @throws IllegalArgumentException if {@code ssl}, {@code address} or {@code context} is {@code null}.
      * @throws ArithmeticException      if {@code connectTimeout} milliseconds overflow as an int
      */
     static Mono<Client> connect(MySqlSslConfiguration ssl, SocketAddress address, boolean tcpKeepAlive,
-                                boolean tcpNoDelay, ConnectionContext context, @Nullable Duration connectTimeout,
-                                LoopResources loopResources) {
+        boolean tcpNoDelay, ConnectionContext context, @Nullable Duration connectTimeout,
+        LoopResources loopResources) {
         requireNonNull(ssl, "ssl must not be null");
         requireNonNull(address, "address must not be null");
         requireNonNull(context, "context must not be null");
 
         TcpClient tcpClient = TcpClient.newConnection()
-                                       .runOn(loopResources);
+            .runOn(loopResources);
 
         if (connectTimeout != null) {
             tcpClient = tcpClient.option(ChannelOption.CONNECT_TIMEOUT_MILLIS,

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/client/MessageDuplexCodec.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/client/MessageDuplexCodec.java
@@ -67,6 +67,9 @@ final class MessageDuplexCodec extends ByteToMessageDecoder implements ChannelOu
 
     private DecodeContext decodeContext = DecodeContext.login();
 
+    /**
+     * It can be retained because reconnect and redirect will re-create the {@link MessageDuplexCodec}.
+     */
     private final ConnectionContext context;
 
     private final ServerMessageDecoder decoder = new ServerMessageDecoder();

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/client/ReactorNettyClient.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/client/ReactorNettyClient.java
@@ -241,6 +241,11 @@ final class ReactorNettyClient implements Client {
     }
 
     @Override
+    public ConnectionContext getContext() {
+        return context;
+    }
+
+    @Override
     public boolean isConnected() {
         return state < ST_CLOSED && connection.channel().isOpen();
     }

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/client/SslBridgeHandler.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/client/SslBridgeHandler.java
@@ -77,6 +77,9 @@ final class SslBridgeHandler extends ChannelDuplexHandler {
 
     private static final ServerVersion MYSQL_5_7_28 = ServerVersion.create(5, 7, 28);
 
+    /**
+     * It can be retained because reconnect and redirect will re-create the {@link SslBridgeHandler}.
+     */
     private final ConnectionContext context;
 
     private final MySqlSslConfiguration ssl;

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/ConnectionContextTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/ConnectionContextTest.java
@@ -46,15 +46,15 @@ public class ConnectionContextTest {
     void setTwiceTimeZone() {
         ConnectionContext context = new ConnectionContext(ZeroDateOption.USE_NULL, null,
             8192, true, null);
-        context.setTimeZone(ZoneId.systemDefault());
-        assertThatIllegalStateException().isThrownBy(() -> context.setTimeZone(ZoneId.systemDefault()));
+        context.initTimeZone(ZoneId.systemDefault());
+        assertThatIllegalStateException().isThrownBy(() -> context.initTimeZone(ZoneId.systemDefault()));
     }
 
     @Test
     void badSetTimeZone() {
         ConnectionContext context = new ConnectionContext(ZeroDateOption.USE_NULL, null,
             8192, true, ZoneId.systemDefault());
-        assertThatIllegalStateException().isThrownBy(() -> context.setTimeZone(ZoneId.systemDefault()));
+        assertThatIllegalStateException().isThrownBy(() -> context.initTimeZone(ZoneId.systemDefault()));
     }
 
     public static ConnectionContext mock() {

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/MySqlBatchingBatchTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/MySqlBatchingBatchTest.java
@@ -29,8 +29,7 @@ import static org.mockito.Mockito.mock;
  */
 class MySqlBatchingBatchTest {
 
-    private final MySqlBatchingBatch batch = new MySqlBatchingBatch(mock(Client.class), mock(Codecs.class),
-        ConnectionContextTest.mock());
+    private final MySqlBatchingBatch batch = new MySqlBatchingBatch(mock(Client.class), mock(Codecs.class));
 
     @Test
     void add() {
@@ -62,8 +61,7 @@ class MySqlBatchingBatchTest {
 
     @Test
     void addNothing() {
-        final MySqlBatchingBatch batch = new MySqlBatchingBatch(mock(Client.class), mock(Codecs.class),
-            ConnectionContextTest.mock());
+        final MySqlBatchingBatch batch = new MySqlBatchingBatch(mock(Client.class), mock(Codecs.class));
         assertEquals(batch.getSql(), "");
     }
 }

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/MySqlSimpleConnectionTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/MySqlSimpleConnectionTest.java
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.when;
  */
 class MySqlSimpleConnectionTest {
 
-    private final Client client = mock(Client.class);
+    private final Client client;
 
     private final Codecs codecs = mock(Codecs.class);
 
@@ -47,20 +47,29 @@ class MySqlSimpleConnectionTest {
 
     private final String product = "MockConnection";
 
-    private final MySqlSimpleConnection noPrepare = new MySqlSimpleConnection(client, ConnectionContextTest.mock(),
-        codecs, level, 50, Caches.createQueryCache(0),
-        Caches.createPrepareCache(0), product, null);
+    private final MySqlSimpleConnection noPrepare;
+
+    MySqlSimpleConnectionTest() {
+        Client client = mock(Client.class);
+
+        when(client.getContext()).thenReturn(ConnectionContextTest.mock());
+
+        this.client = client;
+        this.noPrepare = new MySqlSimpleConnection(client,
+            codecs, level, 50, Caches.createQueryCache(0),
+            Caches.createPrepareCache(0), product, null);
+    }
 
     @Test
     void createStatement() {
         String condition = "SELECT * FROM test";
-        MySqlSimpleConnection allPrepare = new MySqlSimpleConnection(client, ConnectionContextTest.mock(),
+        MySqlSimpleConnection allPrepare = new MySqlSimpleConnection(client,
             codecs, level, 50, Caches.createQueryCache(0),
             Caches.createPrepareCache(0), product, sql -> true);
-        MySqlSimpleConnection halfPrepare = new MySqlSimpleConnection(client, ConnectionContextTest.mock(),
+        MySqlSimpleConnection halfPrepare = new MySqlSimpleConnection(client,
             codecs, level, 50, Caches.createQueryCache(0),
             Caches.createPrepareCache(0), product, sql -> false);
-        MySqlSimpleConnection conditionPrepare = new MySqlSimpleConnection(client, ConnectionContextTest.mock(),
+        MySqlSimpleConnection conditionPrepare = new MySqlSimpleConnection(client,
             codecs, level, 50, Caches.createQueryCache(0),
             Caches.createPrepareCache(0), product, sql -> sql.equals(condition));
 

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/MySqlSyntheticBatchTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/MySqlSyntheticBatchTest.java
@@ -28,8 +28,7 @@ import static org.mockito.Mockito.mock;
  */
 class MySqlSyntheticBatchTest {
 
-    private final MySqlSyntheticBatch batch = new MySqlSyntheticBatch(mock(Client.class), mock(Codecs.class),
-        ConnectionContextTest.mock());
+    private final MySqlSyntheticBatch batch = new MySqlSyntheticBatch(mock(Client.class), mock(Codecs.class));
 
     @SuppressWarnings("ConstantConditions")
     @Test

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/PrepareParametrizedStatementTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/PrepareParametrizedStatementTest.java
@@ -23,13 +23,12 @@ import io.asyncer.r2dbc.mysql.codec.Codecs;
 import java.lang.reflect.Field;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link PrepareParametrizedStatement}.
  */
 class PrepareParametrizedStatementTest implements StatementTestSupport<PrepareParametrizedStatement> {
-
-    private final Client client = mock(Client.class);
 
     private final Codecs codecs = Codecs.builder().build();
 
@@ -46,11 +45,14 @@ class PrepareParametrizedStatementTest implements StatementTestSupport<PreparePa
 
     @Override
     public PrepareParametrizedStatement makeInstance(boolean isMariaDB, String sql, String ignored) {
+        Client client = mock(Client.class);
+
+        when(client.getContext()).thenReturn(ConnectionContextTest.mock(isMariaDB));
+
         return new PrepareParametrizedStatement(
             client,
             codecs,
             Query.parse(sql),
-            ConnectionContextTest.mock(isMariaDB),
             Caches.createPrepareCache(0)
         );
     }

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/PrepareSimpleStatementTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/PrepareSimpleStatementTest.java
@@ -23,13 +23,12 @@ import io.asyncer.r2dbc.mysql.codec.Codecs;
 import java.lang.reflect.Field;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link PrepareSimpleStatement}.
  */
 class PrepareSimpleStatementTest implements StatementTestSupport<PrepareSimpleStatement> {
-
-    private final Client client = mock(Client.class);
 
     private final Codecs codecs = mock(Codecs.class);
 
@@ -61,10 +60,13 @@ class PrepareSimpleStatementTest implements StatementTestSupport<PrepareSimpleSt
 
     @Override
     public PrepareSimpleStatement makeInstance(boolean isMariaDB, String ignored, String sql) {
+        Client client = mock(Client.class);
+
+        when(client.getContext()).thenReturn(ConnectionContextTest.mock(isMariaDB));
+
         return new PrepareSimpleStatement(
             client,
             codecs,
-            ConnectionContextTest.mock(isMariaDB),
             sql,
             Caches.createPrepareCache(0)
         );

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/TextParametrizedStatementTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/TextParametrizedStatementTest.java
@@ -20,13 +20,12 @@ import io.asyncer.r2dbc.mysql.client.Client;
 import io.asyncer.r2dbc.mysql.codec.Codecs;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link TextParametrizedStatement}.
  */
 class TextParametrizedStatementTest implements StatementTestSupport<TextParametrizedStatement> {
-
-    private final Client client = mock(Client.class);
 
     private final Codecs codecs = Codecs.builder().build();
 
@@ -37,11 +36,14 @@ class TextParametrizedStatementTest implements StatementTestSupport<TextParametr
 
     @Override
     public TextParametrizedStatement makeInstance(boolean isMariaDB, String sql, String ignored) {
+        Client client = mock(Client.class);
+
+        when(client.getContext()).thenReturn(ConnectionContextTest.mock(isMariaDB));
+
         return new TextParametrizedStatement(
             client,
             codecs,
-            Query.parse(sql),
-            ConnectionContextTest.mock(isMariaDB)
+            Query.parse(sql)
         );
     }
 

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/TextSimpleStatementTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/TextSimpleStatementTest.java
@@ -20,13 +20,12 @@ import io.asyncer.r2dbc.mysql.client.Client;
 import io.asyncer.r2dbc.mysql.codec.Codecs;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link TextSimpleStatement}.
  */
 class TextSimpleStatementTest implements StatementTestSupport<TextSimpleStatement> {
-
-    private final Client client = mock(Client.class);
 
     private final Codecs codecs = mock(Codecs.class);
 
@@ -52,7 +51,11 @@ class TextSimpleStatementTest implements StatementTestSupport<TextSimpleStatemen
 
     @Override
     public TextSimpleStatement makeInstance(boolean isMariaDB, String ignored, String sql) {
-        return new TextSimpleStatement(client, codecs, ConnectionContextTest.mock(isMariaDB), sql);
+        Client client = mock(Client.class);
+
+        when(client.getContext()).thenReturn(ConnectionContextTest.mock(isMariaDB));
+
+        return new TextSimpleStatement(client, codecs, sql);
     }
 
     @Override


### PR DESCRIPTION
Motivation:

A small refactoring of `ConnectionContext` usage.

It is based on challenges #228 and #89. If a MySQL connection is reconnected or redirected, the `ConnectionContext` needs to be recreated. If we accidentally retain a reference to `ConnectionContext` outside the `client` package, it may cause some unexpected behavior.

Of course, there are some counterexamples here, such as `MySqlDataRow` that needs to retain the `CodecContext` in which it was responded to. Regardless of whether the connection changes, the `CodecContext` should be always the context of the connection which was responding to this row, instead of the current connection.

Modification:

- Reduce publicity
- Prepare to support redirect and reconnect

Result:

Remove `ConnectionContext` reference that's retained outside `client` package, except those required by codecs
