### PR TITLE
Consistent spelling style

### DIFF
--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/Binding.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/Binding.java
@@ -22,9 +22,9 @@ import io.asyncer.r2dbc.mysql.message.client.PreparedTextQueryMessage;
 import java.util.Arrays;
 
 /**
- * A collection of {@link MySqlParameter} for one bind invocation of a parametrized statement.
+ * A collection of {@link MySqlParameter} for one bind invocation of a parameterized statement.
  *
- * @see ParametrizedStatementSupport
+ * @see ParameterizedStatementSupport
  */
 final class Binding {
 
@@ -40,7 +40,7 @@ final class Binding {
      * Add a {@link MySqlParameter} to the binding.
      *
      * @param index the index of the {@link MySqlParameter}
-     * @param value the {@link MySqlParameter} from {@link PrepareParametrizedStatement}
+     * @param value the {@link MySqlParameter} from {@link PrepareParameterizedStatement}
      */
     void add(int index, MySqlParameter value) {
         if (index < 0 || index >= this.values.length) {

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
@@ -883,7 +883,7 @@ public final class MySqlConnectionConfiguration {
         }
 
         /**
-         * Configures the protocol of parametrized statements to the text protocol.
+         * Configures the protocol of parameterized statements to the text protocol.
          * <p>
          * The text protocol is default protocol that's using client-preparing. See also MySQL
          * documentations.
@@ -897,7 +897,7 @@ public final class MySqlConnectionConfiguration {
         }
 
         /**
-         * Configures the protocol of parametrized statements to the binary protocol.
+         * Configures the protocol of parameterized statements to the binary protocol.
          * <p>
          * The binary protocol is compact protocol that's using server-preparing. See also MySQL
          * documentations.
@@ -910,7 +910,7 @@ public final class MySqlConnectionConfiguration {
         }
 
         /**
-         * Configures the protocol of parametrized statements and prepare-preferred simple statements to the
+         * Configures the protocol of parameterized statements and prepare-preferred simple statements to the
          * binary protocol.
          * <p>
          * The {@code preferPrepareStatement} configures whether to prefer prepare execution on a
@@ -1025,7 +1025,7 @@ public final class MySqlConnectionConfiguration {
         /**
          * Configures the maximum size of the server-preparing cache. Usually it should be power of two.
          * Default to {@code 256}. Driver will use unbounded cache if size is less than {@code 0}. It is used
-         * only if using server-preparing parametrized statements, i.e. the {@link #useServerPrepareStatement}
+         * only if using server-preparing parameterized statements, i.e. the {@link #useServerPrepareStatement}
          * is set.
          * <p>
          * Notice: the cache is using EC model (the PACELC theorem) for ensure consistency. Consistency is

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
@@ -201,14 +201,14 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
         Option.valueOf("createDatabaseIfNotExist");
 
     /**
-     * Enable server preparing for parametrized statements and prefer server preparing simple statements.
+     * Enable server preparing for parameterized statements and prefer server preparing simple statements.
      * <p>
      * The value can be a {@link Boolean}. If it is {@code true}, driver will use server preparing for
-     * parametrized statements and text query for simple statements. If it is {@code false}, driver will use
-     * client preparing for parametrized statements and text query for simple statements.
+     * parameterized statements and text query for simple statements. If it is {@code false}, driver will use
+     * client preparing for parameterized statements and text query for simple statements.
      * <p>
      * The value can be a {@link Predicate}{@code <}{@link String}{@code >}. If it is set, driver will server
-     * preparing for parametrized statements, it configures whether to prefer prepare execution on a
+     * preparing for parameterized statements, it configures whether to prefer prepare execution on a
      * statement-by-statement basis (simple statements). The {@link Predicate}{@code <}{@link String}{@code >}
      * accepts the simple SQL query string and returns a {@code boolean} flag indicating preference.
      * <p>

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlSimpleConnection.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlSimpleConnection.java
@@ -256,13 +256,13 @@ final class MySqlSimpleConnection implements MySqlConnection, ConnectionState {
         }
 
         if (prepare == null) {
-            logger.debug("Create a parametrized statement provided by text query");
-            return new TextParametrizedStatement(client, codecs, query);
+            logger.debug("Create a parameterized statement provided by text query");
+            return new TextParameterizedStatement(client, codecs, query);
         }
 
-        logger.debug("Create a parametrized statement provided by prepare query");
+        logger.debug("Create a parameterized statement provided by prepare query");
 
-        return new PrepareParametrizedStatement(client, codecs, query, prepareCache);
+        return new PrepareParameterizedStatement(client, codecs, query, prepareCache);
     }
 
     @Override

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/ParameterWriter.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/ParameterWriter.java
@@ -25,7 +25,7 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 
 /**
- * A writer for {@link MySqlParameter}s of parametrized statements with text-based protocol.
+ * A writer for {@link MySqlParameter}s of parameterized statements with text-based protocol.
  */
 public abstract class ParameterWriter extends Writer {
 

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/ParameterizedStatementSupport.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/ParameterizedStatementSupport.java
@@ -34,12 +34,12 @@ import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.require;
 import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.requireNonNull;
 
 /**
- * Base class considers parametrized {@link MySqlStatement} with parameter markers.
+ * Base class considers parameterized {@link MySqlStatement} with parameter markers.
  * <p>
  * MySQL uses indexed parameters which are marked by {@literal ?} without naming. Implementations should use
  * {@link Query} to supports named parameters.
  */
-abstract class ParametrizedStatementSupport extends MySqlStatementSupport {
+abstract class ParameterizedStatementSupport extends MySqlStatementSupport {
 
     protected final Codecs codecs;
 
@@ -49,7 +49,7 @@ abstract class ParametrizedStatementSupport extends MySqlStatementSupport {
 
     private final AtomicBoolean executed = new AtomicBoolean();
 
-    ParametrizedStatementSupport(Client client, Codecs codecs, Query query) {
+    ParameterizedStatementSupport(Client client, Codecs codecs, Query query) {
         super(client);
 
         requireNonNull(query, "query must not be null");
@@ -113,7 +113,7 @@ abstract class ParametrizedStatementSupport extends MySqlStatementSupport {
 
         return Flux.defer(() -> {
             if (!executed.compareAndSet(false, true)) {
-                return Flux.error(new IllegalStateException("Parametrized statement was already executed"));
+                return Flux.error(new IllegalStateException("Parameterized statement was already executed"));
             }
 
             return execute(bindings.bindings);

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/PrepareParameterizedStatement.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/PrepareParameterizedStatement.java
@@ -29,15 +29,15 @@ import java.util.List;
 import static io.asyncer.r2dbc.mysql.internal.util.AssertUtils.require;
 
 /**
- * An implementation of {@link ParametrizedStatementSupport} based on MySQL prepare query.
+ * An implementation of {@link ParameterizedStatementSupport} based on MySQL prepare query.
  */
-final class PrepareParametrizedStatement extends ParametrizedStatementSupport {
+final class PrepareParameterizedStatement extends ParameterizedStatementSupport {
 
     private final PrepareCache prepareCache;
 
     private int fetchSize = 0;
 
-    PrepareParametrizedStatement(Client client, Codecs codecs, Query query, PrepareCache prepareCache) {
+    PrepareParameterizedStatement(Client client, Codecs codecs, Query query, PrepareCache prepareCache) {
         super(client, codecs, query);
         this.prepareCache = prepareCache;
     }

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/QueryFlow.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/QueryFlow.java
@@ -87,8 +87,8 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 /**
- * A message flow considers both of parametrized and text queries, such as {@link TextParametrizedStatement},
- * {@link PrepareParametrizedStatement}, {@link TextSimpleStatement}, {@link PrepareSimpleStatement} and
+ * A message flow considers both of parameterized and text queries, such as {@link TextParameterizedStatement},
+ * {@link PrepareParameterizedStatement}, {@link TextSimpleStatement}, {@link PrepareSimpleStatement} and
  * {@link MySqlBatch}.
  */
 final class QueryFlow {

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/TextParameterizedStatement.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/TextParameterizedStatement.java
@@ -24,11 +24,11 @@ import reactor.core.publisher.Flux;
 import java.util.List;
 
 /**
- * An implementation of {@link ParametrizedStatementSupport} based on MySQL text query.
+ * An implementation of {@link ParameterizedStatementSupport} based on MySQL text query.
  */
-final class TextParametrizedStatement extends ParametrizedStatementSupport {
+final class TextParameterizedStatement extends ParameterizedStatementSupport {
 
-    TextParametrizedStatement(Client client, Codecs codecs, Query query) {
+    TextParameterizedStatement(Client client, Codecs codecs, Query query) {
         super(client, codecs, query);
     }
 

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/api/MySqlStatement.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/api/MySqlStatement.java
@@ -35,7 +35,7 @@ public interface MySqlStatement extends Statement {
      * {@inheritDoc}
      *
      * @return {@link MySqlStatement this}
-     * @throws IllegalStateException if the statement is parametrized and not all parameters are provided
+     * @throws IllegalStateException if the statement is parameterized and not all parameters are provided
      */
     @Override
     MySqlStatement add();
@@ -96,7 +96,7 @@ public interface MySqlStatement extends Statement {
      * {@inheritDoc}
      *
      * @return a {@link Flux} representing {@link MySqlResult}s of the statement
-     * @throws IllegalStateException if the statement is parametrized and not all parameters are provided
+     * @throws IllegalStateException if the statement is parameterized and not all parameters are provided
      */
     @Override
     Flux<? extends MySqlResult> execute();

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/Codec.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/Codec.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Codec to encode and decode values based on MySQL data binary/text protocol.
  * <p>
- * Use {@link ParametrizedCodec} for support {@code ParameterizedType} encoding/decoding.
+ * Use {@link ParameterizedCodec} for support {@code ParameterizedType} encoding/decoding.
  *
  * @param <T> the type that is handled by this codec.
  */

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/DefaultCodecs.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/DefaultCodecs.java
@@ -44,11 +44,11 @@ final class DefaultCodecs implements Codecs {
 
     private final Codec<?>[] codecs;
 
-    private final ParametrizedCodec<?>[] parametrizedCodecs;
+    private final ParameterizedCodec<?>[] parameterizedCodecs;
 
     private final MassiveCodec<?>[] massiveCodecs;
 
-    private final MassiveParametrizedCodec<?>[] massiveParametrizedCodecs;
+    private final MassiveParameterizedCodec<?>[] massiveParameterizedCodecs;
 
     private final Map<Type, PrimitiveCodec<?>> primitiveCodecs;
 
@@ -56,32 +56,32 @@ final class DefaultCodecs implements Codecs {
         this.codecs = requireNonNull(codecs, "codecs must not be null");
 
         Map<Type, PrimitiveCodec<?>> primitiveCodecs = new HashMap<>();
-        List<ParametrizedCodec<?>> parametrizedCodecs = new ArrayList<>();
+        List<ParameterizedCodec<?>> parameterizedCodecs = new ArrayList<>();
         List<MassiveCodec<?>> massiveCodecs = new ArrayList<>();
-        List<MassiveParametrizedCodec<?>> massiveParamCodecs = new ArrayList<>();
+        List<MassiveParameterizedCodec<?>> massiveParamCodecs = new ArrayList<>();
 
         for (Codec<?> codec : codecs) {
             if (codec instanceof PrimitiveCodec<?>) {
                 // Primitive codec must be class-based codec, cannot support ParameterizedType.
                 PrimitiveCodec<?> c = (PrimitiveCodec<?>) codec;
                 primitiveCodecs.put(c.getPrimitiveClass(), c);
-            } else if (codec instanceof ParametrizedCodec<?>) {
-                parametrizedCodecs.add((ParametrizedCodec<?>) codec);
+            } else if (codec instanceof ParameterizedCodec<?>) {
+                parameterizedCodecs.add((ParameterizedCodec<?>) codec);
             }
 
             if (codec instanceof MassiveCodec<?>) {
                 massiveCodecs.add((MassiveCodec<?>) codec);
 
-                if (codec instanceof MassiveParametrizedCodec<?>) {
-                    massiveParamCodecs.add((MassiveParametrizedCodec<?>) codec);
+                if (codec instanceof MassiveParameterizedCodec<?>) {
+                    massiveParamCodecs.add((MassiveParameterizedCodec<?>) codec);
                 }
             }
         }
 
         this.primitiveCodecs = primitiveCodecs;
         this.massiveCodecs = massiveCodecs.toArray(new MassiveCodec<?>[0]);
-        this.massiveParametrizedCodecs = massiveParamCodecs.toArray(new MassiveParametrizedCodec<?>[0]);
-        this.parametrizedCodecs = parametrizedCodecs.toArray(new ParametrizedCodec<?>[0]);
+        this.massiveParameterizedCodecs = massiveParamCodecs.toArray(new MassiveParameterizedCodec<?>[0]);
+        this.parameterizedCodecs = parameterizedCodecs.toArray(new ParameterizedCodec<?>[0]);
     }
 
     /**
@@ -230,7 +230,7 @@ final class DefaultCodecs implements Codecs {
     @Nullable
     private <T> T decodeNormal(NormalFieldValue value, MySqlReadableMetadata metadata, ParameterizedType type,
         boolean binary, CodecContext context) {
-        for (ParametrizedCodec<?> codec : parametrizedCodecs) {
+        for (ParameterizedCodec<?> codec : parameterizedCodecs) {
             if (codec.canDecode(metadata, type)) {
                 @SuppressWarnings("unchecked")
                 T result = (T) codec.decode(value.getBufferSlice(), metadata, type, binary, context);
@@ -258,7 +258,7 @@ final class DefaultCodecs implements Codecs {
     @Nullable
     private <T> T decodeMassive(LargeFieldValue value, MySqlReadableMetadata metadata, ParameterizedType type,
         boolean binary, CodecContext context) {
-        for (MassiveParametrizedCodec<?> codec : massiveParametrizedCodecs) {
+        for (MassiveParameterizedCodec<?> codec : massiveParameterizedCodecs) {
             if (codec.canDecode(metadata, type)) {
                 @SuppressWarnings("unchecked")
                 T result = (T) codec.decodeMassive(value.getBufferSlices(), metadata, type, binary, context);

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/LocalDateTimeCodec.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/LocalDateTimeCodec.java
@@ -36,7 +36,7 @@ import java.time.chrono.ChronoLocalDateTime;
  * <p>
  * For now, supports only A.D. calendar in {@link ChronoLocalDateTime}.
  */
-final class LocalDateTimeCodec implements ParametrizedCodec<LocalDateTime> {
+final class LocalDateTimeCodec implements ParameterizedCodec<LocalDateTime> {
 
     static final LocalDateTimeCodec INSTANCE = new LocalDateTimeCodec();
 

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/MassiveParameterizedCodec.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/MassiveParameterizedCodec.java
@@ -28,7 +28,7 @@ import java.util.List;
  *
  * @param <T> the type that is handled by this codec.
  */
-public interface MassiveParametrizedCodec<T> extends ParametrizedCodec<T>, MassiveCodec<T> {
+public interface MassiveParameterizedCodec<T> extends ParameterizedCodec<T>, MassiveCodec<T> {
 
     /**
      * Decode a massive value as specified {@link ParameterizedType}.

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/ParameterizedCodec.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/ParameterizedCodec.java
@@ -29,7 +29,7 @@ import java.lang.reflect.ParameterizedType;
  *
  * @param <T> the type without parameter that is handled by this codec.
  */
-public interface ParametrizedCodec<T> extends Codec<T> {
+public interface ParameterizedCodec<T> extends Codec<T> {
 
     /**
      * Decodes a {@link ByteBuf} as specified {@link ParameterizedType}.

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/SetCodec.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/SetCodec.java
@@ -41,7 +41,7 @@ import static io.asyncer.r2dbc.mysql.internal.util.InternalArrays.EMPTY_STRINGS;
  * Codec for {@link Set}{@code <}{@link String}{@code >}, {@link Set}{@code <}{@link Enum}{@code >} and the
  * {@link String}{@code []}.
  */
-final class SetCodec implements ParametrizedCodec<String[]> {
+final class SetCodec implements ParameterizedCodec<String[]> {
 
     static final SetCodec INSTANCE = new SetCodec();
 

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/ZonedDateTimeCodec.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/ZonedDateTimeCodec.java
@@ -37,7 +37,7 @@ import java.time.chrono.ChronoZonedDateTime;
  * <p>
  * For now, supports only A.D. calendar in {@link ChronoZonedDateTime}.
  */
-final class ZonedDateTimeCodec implements ParametrizedCodec<ZonedDateTime> {
+final class ZonedDateTimeCodec implements ParameterizedCodec<ZonedDateTime> {
 
     static final ZonedDateTimeCodec INSTANCE = new ZonedDateTimeCodec();
 

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/MySqlSimpleConnectionTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/MySqlSimpleConnectionTest.java
@@ -78,28 +78,28 @@ class MySqlSimpleConnectionTest {
         assertThat(noPrepare.createStatement(condition))
             .isExactlyInstanceOf(TextSimpleStatement.class);
         assertThat(noPrepare.createStatement("SELECT * FROM test WHERE id=?"))
-            .isExactlyInstanceOf(TextParametrizedStatement.class);
+            .isExactlyInstanceOf(TextParameterizedStatement.class);
 
         assertThat(allPrepare.createStatement("SELECT * FROM test WHERE id=1"))
             .isExactlyInstanceOf(PrepareSimpleStatement.class);
         assertThat(allPrepare.createStatement(condition))
             .isExactlyInstanceOf(PrepareSimpleStatement.class);
         assertThat(allPrepare.createStatement("SELECT * FROM test WHERE id=?"))
-            .isExactlyInstanceOf(PrepareParametrizedStatement.class);
+            .isExactlyInstanceOf(PrepareParameterizedStatement.class);
 
         assertThat(halfPrepare.createStatement("SELECT * FROM test WHERE id=1"))
             .isExactlyInstanceOf(TextSimpleStatement.class);
         assertThat(halfPrepare.createStatement(condition))
             .isExactlyInstanceOf(TextSimpleStatement.class);
         assertThat(halfPrepare.createStatement("SELECT * FROM test WHERE id=?"))
-            .isExactlyInstanceOf(PrepareParametrizedStatement.class);
+            .isExactlyInstanceOf(PrepareParameterizedStatement.class);
 
         assertThat(conditionPrepare.createStatement("SELECT * FROM test WHERE id=1"))
             .isExactlyInstanceOf(TextSimpleStatement.class);
         assertThat(conditionPrepare.createStatement(condition))
             .isExactlyInstanceOf(PrepareSimpleStatement.class);
         assertThat(conditionPrepare.createStatement("SELECT * FROM test WHERE id=?"))
-            .isExactlyInstanceOf(PrepareParametrizedStatement.class);
+            .isExactlyInstanceOf(PrepareParameterizedStatement.class);
     }
 
     @SuppressWarnings("ConstantConditions")

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/PrepareParameterizedStatementTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/PrepareParameterizedStatementTest.java
@@ -16,34 +16,44 @@
 
 package io.asyncer.r2dbc.mysql;
 
+import io.asyncer.r2dbc.mysql.cache.Caches;
 import io.asyncer.r2dbc.mysql.client.Client;
 import io.asyncer.r2dbc.mysql.codec.Codecs;
+
+import java.lang.reflect.Field;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Unit tests for {@link TextParametrizedStatement}.
+ * Unit tests for {@link PrepareParameterizedStatement}.
  */
-class TextParametrizedStatementTest implements StatementTestSupport<TextParametrizedStatement> {
+class PrepareParameterizedStatementTest implements StatementTestSupport<PrepareParameterizedStatement> {
 
     private final Codecs codecs = Codecs.builder().build();
 
-    @Override
-    public void fetchSize() {
-        // No-op
+    private final Field fetchSize = PrepareParameterizedStatement.class.getDeclaredField("fetchSize");
+
+    PrepareParameterizedStatementTest() throws NoSuchFieldException {
+        fetchSize.setAccessible(true);
     }
 
     @Override
-    public TextParametrizedStatement makeInstance(boolean isMariaDB, String sql, String ignored) {
+    public int getFetchSize(PrepareParameterizedStatement statement) throws IllegalAccessException {
+        return fetchSize.getInt(statement);
+    }
+
+    @Override
+    public PrepareParameterizedStatement makeInstance(boolean isMariaDB, String sql, String ignored) {
         Client client = mock(Client.class);
 
         when(client.getContext()).thenReturn(ConnectionContextTest.mock(isMariaDB));
 
-        return new TextParametrizedStatement(
+        return new PrepareParameterizedStatement(
             client,
             codecs,
-            Query.parse(sql)
+            Query.parse(sql),
+            Caches.createPrepareCache(0)
         );
     }
 

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/PrepareQueryIntegrationTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/PrepareQueryIntegrationTest.java
@@ -24,7 +24,7 @@ import java.util.Arrays;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * Integration tests for {@link PrepareParametrizedStatement} and {@link PrepareSimpleStatement}.
+ * Integration tests for {@link PrepareParameterizedStatement} and {@link PrepareSimpleStatement}.
  */
 class PrepareQueryIntegrationTest extends QueryIntegrationTestSupport {
 

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/StatementTestSupport.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/StatementTestSupport.java
@@ -32,11 +32,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 interface StatementTestSupport<T extends MySqlStatementSupport> {
 
-    String PARAMETRIZED = "SELECT * FROM test WHERE id = ?id AND name = ?";
+    String PARAMETERIZED = "SELECT * FROM test WHERE id = ?id AND name = ?";
 
     String SIMPLE = "SELECT * FROM test WHERE id = 1 AND name = 'Mirrors'";
 
-    T makeInstance(boolean isMariaDB, String parametrizedSql, String simpleSql);
+    T makeInstance(boolean isMariaDB, String parameterizedSql, String simpleSql);
 
     boolean supportsBinding();
 
@@ -48,7 +48,7 @@ interface StatementTestSupport<T extends MySqlStatementSupport> {
     default void bind() {
         assertTrue(supportsBinding(), "Must skip test case #bind() for simple statements");
 
-        T statement = makeInstance(false, PARAMETRIZED, SIMPLE);
+        T statement = makeInstance(false, PARAMETERIZED, SIMPLE);
         statement.bind(0, 1);
         statement.bind("id", 1);
         statement.bind(1, 1);
@@ -57,7 +57,7 @@ interface StatementTestSupport<T extends MySqlStatementSupport> {
     @SuppressWarnings("ConstantConditions")
     @Test
     default void badBind() {
-        T statement = makeInstance(false, PARAMETRIZED, SIMPLE);
+        T statement = makeInstance(false, PARAMETERIZED, SIMPLE);
 
         if (supportsBinding()) {
             assertThrows(IllegalArgumentException.class, () -> statement.bind(0, null));
@@ -89,7 +89,7 @@ interface StatementTestSupport<T extends MySqlStatementSupport> {
     default void bindNull() {
         assertTrue(supportsBinding(), "Must skip test case #bindNull() for simple statements");
 
-        T statement = makeInstance(false, PARAMETRIZED, SIMPLE);
+        T statement = makeInstance(false, PARAMETERIZED, SIMPLE);
         statement.bindNull(0, Integer.class);
         statement.bindNull("id", Integer.class);
         statement.bindNull(1, Integer.class);
@@ -98,7 +98,7 @@ interface StatementTestSupport<T extends MySqlStatementSupport> {
     @SuppressWarnings("ConstantConditions")
     @Test
     default void badBindNull() {
-        T statement = makeInstance(false, PARAMETRIZED, SIMPLE);
+        T statement = makeInstance(false, PARAMETERIZED, SIMPLE);
 
         if (supportsBinding()) {
             assertThrows(IllegalArgumentException.class, () -> statement.bindNull(0, null));
@@ -128,7 +128,7 @@ interface StatementTestSupport<T extends MySqlStatementSupport> {
 
     @Test
     default void add() {
-        T statement = makeInstance(false, PARAMETRIZED, SIMPLE);
+        T statement = makeInstance(false, PARAMETERIZED, SIMPLE);
 
         if (!supportsBinding()) {
             statement.add();
@@ -146,14 +146,14 @@ interface StatementTestSupport<T extends MySqlStatementSupport> {
     default void badAdd() {
         assertTrue(supportsBinding(), "Must skip test case #badAdd() for simple statements");
 
-        T statement = makeInstance(false, PARAMETRIZED, SIMPLE);
+        T statement = makeInstance(false, PARAMETERIZED, SIMPLE);
         statement.bind(0, 1);
         assertThrows(IllegalStateException.class, statement::add);
     }
 
     @Test
     default void mySqlReturnGeneratedValues() {
-        T s = makeInstance(false, PARAMETRIZED, SIMPLE);
+        T s = makeInstance(false, PARAMETERIZED, SIMPLE);
 
         s.returnGeneratedValues();
 
@@ -173,7 +173,7 @@ interface StatementTestSupport<T extends MySqlStatementSupport> {
 
     @Test
     default void mariaDbReturnGeneratedValues() {
-        T s = makeInstance(true, PARAMETRIZED, SIMPLE);
+        T s = makeInstance(true, PARAMETERIZED, SIMPLE);
 
         s.returnGeneratedValues();
 
@@ -203,7 +203,7 @@ interface StatementTestSupport<T extends MySqlStatementSupport> {
     @SuppressWarnings("ConstantConditions")
     @Test
     default void badReturnGeneratedValues() {
-        T s = makeInstance(false, PARAMETRIZED, SIMPLE);
+        T s = makeInstance(false, PARAMETERIZED, SIMPLE);
 
         assertThatIllegalArgumentException().isThrownBy(() -> s.returnGeneratedValues((String) null));
         assertThatIllegalArgumentException().isThrownBy(() -> s.returnGeneratedValues((String[]) null));
@@ -215,7 +215,7 @@ interface StatementTestSupport<T extends MySqlStatementSupport> {
     @SuppressWarnings("ConstantConditions")
     @Test
     default void mariaDbBadReturnGeneratedValues() {
-        T s = makeInstance(true, PARAMETRIZED, SIMPLE);
+        T s = makeInstance(true, PARAMETERIZED, SIMPLE);
 
         assertThatIllegalArgumentException().isThrownBy(() -> s.returnGeneratedValues((String) null));
         assertThatIllegalArgumentException().isThrownBy(() -> s.returnGeneratedValues((String[]) null));
@@ -229,7 +229,7 @@ interface StatementTestSupport<T extends MySqlStatementSupport> {
 
     @Test
     default void fetchSize() throws IllegalAccessException {
-        T statement = makeInstance(false, PARAMETRIZED, SIMPLE);
+        T statement = makeInstance(false, PARAMETERIZED, SIMPLE);
         assertEquals(0, getFetchSize(statement), "Must skip test case #fetchSize() for text-based queries");
 
         for (int i = 1; i <= 10; ++i) {
@@ -247,7 +247,7 @@ interface StatementTestSupport<T extends MySqlStatementSupport> {
 
     @Test
     default void badFetchSize() {
-        T statement = makeInstance(false, PARAMETRIZED, SIMPLE);
+        T statement = makeInstance(false, PARAMETERIZED, SIMPLE);
 
         assertThrows(IllegalArgumentException.class, () -> statement.fetchSize(-1));
         assertThrows(IllegalArgumentException.class, () -> statement.fetchSize(-10));

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/TextParameterizedStatementTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/TextParameterizedStatementTest.java
@@ -16,44 +16,34 @@
 
 package io.asyncer.r2dbc.mysql;
 
-import io.asyncer.r2dbc.mysql.cache.Caches;
 import io.asyncer.r2dbc.mysql.client.Client;
 import io.asyncer.r2dbc.mysql.codec.Codecs;
-
-import java.lang.reflect.Field;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Unit tests for {@link PrepareParametrizedStatement}.
+ * Unit tests for {@link TextParameterizedStatement}.
  */
-class PrepareParametrizedStatementTest implements StatementTestSupport<PrepareParametrizedStatement> {
+class TextParameterizedStatementTest implements StatementTestSupport<TextParameterizedStatement> {
 
     private final Codecs codecs = Codecs.builder().build();
 
-    private final Field fetchSize = PrepareParametrizedStatement.class.getDeclaredField("fetchSize");
-
-    PrepareParametrizedStatementTest() throws NoSuchFieldException {
-        fetchSize.setAccessible(true);
+    @Override
+    public void fetchSize() {
+        // No-op
     }
 
     @Override
-    public int getFetchSize(PrepareParametrizedStatement statement) throws IllegalAccessException {
-        return fetchSize.getInt(statement);
-    }
-
-    @Override
-    public PrepareParametrizedStatement makeInstance(boolean isMariaDB, String sql, String ignored) {
+    public TextParameterizedStatement makeInstance(boolean isMariaDB, String sql, String ignored) {
         Client client = mock(Client.class);
 
         when(client.getContext()).thenReturn(ConnectionContextTest.mock(isMariaDB));
 
-        return new PrepareParametrizedStatement(
+        return new TextParameterizedStatement(
             client,
             codecs,
-            Query.parse(sql),
-            Caches.createPrepareCache(0)
+            Query.parse(sql)
         );
     }
 

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/TextQueryIntegrationTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/TextQueryIntegrationTest.java
@@ -17,7 +17,7 @@
 package io.asyncer.r2dbc.mysql;
 
 /**
- * Integration tests for {@link TextSimpleStatement} and {@link TextParametrizedStatement}.
+ * Integration tests for {@link TextSimpleStatement} and {@link TextParameterizedStatement}.
  */
 class TextQueryIntegrationTest extends QueryIntegrationTestSupport {
 

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/json/JacksonCodec.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/json/JacksonCodec.java
@@ -21,8 +21,7 @@ import io.asyncer.r2dbc.mysql.MySqlParameter;
 import io.asyncer.r2dbc.mysql.ParameterWriter;
 import io.asyncer.r2dbc.mysql.api.MySqlReadableMetadata;
 import io.asyncer.r2dbc.mysql.codec.CodecContext;
-import io.asyncer.r2dbc.mysql.codec.ParametrizedCodec;
-import io.asyncer.r2dbc.mysql.collation.CharCollation;
+import io.asyncer.r2dbc.mysql.codec.ParameterizedCodec;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.asyncer.r2dbc.mysql.internal.util.VarIntUtils;
 import io.netty.buffer.ByteBuf;
@@ -42,7 +41,7 @@ import java.nio.charset.Charset;
 /**
  * A JSON codec based on Jackson.
  */
-public final class JacksonCodec implements ParametrizedCodec<Object> {
+public final class JacksonCodec implements ParameterizedCodec<Object> {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 


### PR DESCRIPTION
Motivation:

Consistent English spelling style, change `Parametrized` (British) -> `Parameterized` (US)

Modification:

It causes `ParametrizedCodec` to be changed to `ParameterizedCodec`, it should be fine.

- Almost no one uses `ParametrizedCodec`
- We are trying to mark getting an object using `ParameterizedType` as [an unstable API](https://github.com/asyncer-io/r2dbc-mysql/commit/09a2246a625e4494b291d590c0eed1ac2330d663#diff-672c2190e40b06e8b804c48dcd521e31c22eff4c30b15ac57382264e643ca443R53)

Result:

Consistent English spelling style.
