### PR TITLE
Add support for SQL mode `NO_BACKSLASH_ESCAPES`

### DIFF
--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/ConnectionContext.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/ConnectionContext.java
@@ -216,6 +216,10 @@ public final class ConnectionContext implements CodecContext {
         return (capability != null && capability.isMariaDb()) || serverVersion.isMariaDb();
     }
 
+    public boolean isNoBackslashEscapes() {
+        return (serverStatuses & ServerStatuses.NO_BACKSLASH_ESCAPES) != 0;
+    }
+
     @Override
     public ZeroDateOption getZeroDateOption() {
         return zeroDateOption;

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/constant/ServerStatuses.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/constant/ServerStatuses.java
@@ -50,12 +50,20 @@ public final class ServerStatuses {
     public static final short LAST_ROW_SENT = 128;
 
 //    public static final short DB_DROPPED = 256;
-//    public static final short NO_BACKSLASH_ESCAPES = 512;
+
+    /**
+     * Server does not permit backslash escapes.
+     *
+     * @since 1.1.3
+     */
+    public static final short NO_BACKSLASH_ESCAPES = 512;
+
 //    public static final short METADATA_CHANGED = 1024;
 //    public static final short QUERY_WAS_SLOW = 2048;
 //    public static final short PS_OUT_PARAMS = 4096;
 //    public static final short IN_TRANS_READONLY = 8192;
 //    public static final short SESSION_STATE_CHANGED = 16384;
 
-    private ServerStatuses() { }
+    private ServerStatuses() {
+    }
 }

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/message/client/PreparedTextQueryMessage.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/message/client/PreparedTextQueryMessage.java
@@ -87,7 +87,7 @@ public final class PreparedTextQueryMessage extends AtomicReference<MySqlParamet
             return Flux.fromArray(values);
         });
 
-        return ParamWriter.publish(query, parameters).handle((it, sink) -> {
+        return ParamWriter.publish(context.isNoBackslashEscapes(), query, parameters).handle((it, sink) -> {
             ByteBuf buf = allocator.buffer();
 
             try {

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/ConnectionIntegrationTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/ConnectionIntegrationTest.java
@@ -50,6 +50,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import static io.r2dbc.spi.IsolationLevel.READ_COMMITTED;
 import static io.r2dbc.spi.IsolationLevel.READ_UNCOMMITTED;
@@ -78,6 +79,53 @@ class ConnectionIntegrationTest extends IntegrationTestSupport {
             .doOnSuccess(ignored -> assertThat(connection.context().isInTransaction()).isTrue())
             .then(connection.rollbackTransaction())
             .doOnSuccess(ignored -> assertThat(connection.context().isInTransaction()).isFalse()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "test",
+        "test`data",
+        "test\ndata",
+        "I'm feeling good",
+    })
+    void sqlModeNoBackslashEscapes(String value) {
+        String tdl = "CREATE TEMPORARY TABLE `test` (`id` INT NOT NULL PRIMARY KEY, `value` VARCHAR(50) NOT NULL)";
+
+        // Add NO_BACKSLASH_ESCAPES instead of replace
+        castedComplete(connection -> Mono.fromRunnable(() -> assertThat(connection.context().isNoBackslashEscapes())
+                .isFalse())
+            .thenMany(connection.createStatement(tdl).execute())
+            .flatMap(MySqlResult::getRowsUpdated)
+            .thenMany(connection.createStatement("INSERT INTO test VALUES (1, ?)")
+                .bind(0, value)
+                .execute())
+            .flatMap(MySqlResult::getRowsUpdated)
+            .thenMany(connection.createStatement("SELECT COUNT(0) FROM `test` WHERE `value` = ?")
+                .bind(0, value)
+                .execute())
+            .flatMap(result -> result.map((row, metadata) -> row.get(0, Integer.class)))
+            .collectList()
+            .doOnNext(counts -> assertThat(counts).isEqualTo(Collections.singletonList(1)))
+            .thenMany(connection.createStatement("SELECT @@sql_mode").execute())
+            .flatMap(result -> result.map((row, metadata) -> row.get(0, String.class)))
+            .map(modes -> Stream.concat(Stream.of(modes.split(",")), Stream.of("NO_BACKSLASH_ESCAPES"))
+                .toArray(String[]::new))
+            .last()
+            .flatMapMany(modes -> connection.createStatement("SET sql_mode = ?")
+                .bind(0, modes)
+                .execute())
+            .flatMap(MySqlResult::getRowsUpdated)
+            .doOnComplete(() -> assertThat(connection.context().isNoBackslashEscapes()).isTrue())
+            .thenMany(connection.createStatement("INSERT INTO test VALUES (2, ?)")
+                .bind(0, value)
+                .execute())
+            .flatMap(MySqlResult::getRowsUpdated)
+            .thenMany(connection.createStatement("SELECT COUNT(0) FROM `test` WHERE `value` = ?")
+                .bind(0, value)
+                .execute())
+            .flatMap(result -> result.map((row, metadata) -> row.get(0, Integer.class)))
+            .collectList()
+            .doOnNext(counts -> assertThat(counts).isEqualTo(Collections.singletonList(2))));
     }
 
     @DisabledIf("envIsLessThanMySql56")

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/QueryIntegrationTestSupport.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/QueryIntegrationTestSupport.java
@@ -564,7 +564,7 @@ abstract class QueryIntegrationTestSupport extends IntegrationTestSupport {
                 .bind(2, 20)
                 .execute())
             .flatMap(IntegrationTestSupport::extractRowsUpdated)
-            .doOnNext(it -> assertThat(it).isOne()) // TODO: check capability flag
+            .doOnNext(it -> assertThat(it).isOne())
             .thenMany(connection.createStatement("SELECT value FROM test WHERE id=?")
                 .bind(0, 1)
                 .execute())

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/codec/CodecTestSupport.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/codec/CodecTestSupport.java
@@ -91,7 +91,7 @@ interface CodecTestSupport<T> {
         Query query = Query.parse("?");
 
         for (int i = 0; i < origin.length; ++i) {
-            ParameterWriter writer = ParameterWriterHelper.get(query);
+            ParameterWriter writer = ParameterWriterHelper.get(false, query);
             codec.encode(origin[i], context())
                 .publishText(writer)
                 .as(StepVerifier::create)

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/codec/SetCodecTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/codec/SetCodecTest.java
@@ -129,7 +129,7 @@ class SetCodecTest implements CodecTestSupport<String[]> {
         Query query = Query.parse("?");
 
         for (int i = 0; i < sets.length; ++i) {
-            ParameterWriter writer = ParameterWriterHelper.get(query);
+            ParameterWriter writer = ParameterWriterHelper.get(false, query);
             codec.encode(sets[i], context())
                 .publishText(writer)
                 .as(StepVerifier::create)

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/message/client/ParameterWriterHelper.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/message/client/ParameterWriterHelper.java
@@ -45,10 +45,10 @@ public final class ParameterWriterHelper {
         ReflectionUtils.findMethod(ParamWriter.class, "toSql")
             .orElseThrow(RuntimeException::new);
 
-    public static ParameterWriter get(Query query) {
+    public static ParameterWriter get(boolean noBackslashEscapes, Query query) {
         assertThat(query.getPartSize()).isGreaterThan(1);
 
-        return ReflectionUtils.newInstance(CONSTRUCTOR, query);
+        return ReflectionUtils.newInstance(CONSTRUCTOR, noBackslashEscapes, query);
     }
 
     public static String toSql(ParameterWriter writer) {


### PR DESCRIPTION
Motivation:

Resolves #267 

Modification:

- `ParamWriter` skips backslash escaping if `NO_BACKSLASH_ESCAPES` is set
- Load `innodb_lock_wait_timeout` without escaping

And unit tests and integration tests for `NO_BACKSLASH_ESCAPES`.

Result:

SQL mode `NO_BACKSLASH_ESCAPES` supported
