### PR TITLE
feat: support config AddressResolverGroup in r2dbc-mysql

### DIFF
--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
@@ -369,14 +369,19 @@ public final class MySqlConnectionConfiguration {
 
     @Override
     public String toString() {
-        if (isHost) {
-            return "MySqlConnectionConfiguration{host='" + domain + "', port=" + port + ", ssl=" + ssl +
-                ", tcpNoDelay=" + tcpNoDelay + ", tcpKeepAlive=" + tcpKeepAlive +
-                ", connectTimeout=" + connectTimeout +
+        return "MySqlConnectionConfiguration{" +
+                (isHost ? "host='" + domain + "', port=" + port + ", ssl=" + ssl : "unixSocket='" + domain + "'") +
+                buildCommonToStringPart() +
+                '}';
+    }
+
+    private String buildCommonToStringPart() {
+        return ", connectTimeout=" + connectTimeout +
                 ", preserveInstants=" + preserveInstants +
                 ", connectionTimeZone=" + connectionTimeZone +
                 ", forceConnectionTimeZoneToSession=" + forceConnectionTimeZoneToSession +
-                ", zeroDateOption=" + zeroDateOption + ", user='" + user + "', password=" + password +
+                ", zeroDateOption=" + zeroDateOption +
+                ", user='" + user + "', password=" + password +
                 ", database='" + database + "', createDatabaseIfNotExist=" + createDatabaseIfNotExist +
                 ", preferPrepareStatement=" + preferPrepareStatement +
                 ", sessionVariables=" + sessionVariables +
@@ -384,36 +389,14 @@ public final class MySqlConnectionConfiguration {
                 ", statementTimeout=" + statementTimeout +
                 ", loadLocalInfilePath=" + loadLocalInfilePath +
                 ", localInfileBufferSize=" + localInfileBufferSize +
-                ", queryCacheSize=" + queryCacheSize + ", prepareCacheSize=" + prepareCacheSize +
+                ", queryCacheSize=" + queryCacheSize +
+                ", prepareCacheSize=" + prepareCacheSize +
                 ", compressionAlgorithms=" + compressionAlgorithms +
                 ", zstdCompressionLevel=" + zstdCompressionLevel +
                 ", loopResources=" + loopResources +
-                ", extensions=" + extensions + ", passwordPublisher=" + passwordPublisher +
-                ", resolver=" + resolver +
-                '}';
-        }
-
-        return "MySqlConnectionConfiguration{unixSocket='" + domain +
-            "', connectTimeout=" + connectTimeout +
-            ", preserveInstants=" + preserveInstants +
-            ", connectionTimeZone=" + connectionTimeZone +
-            ", forceConnectionTimeZoneToSession=" + forceConnectionTimeZoneToSession +
-            ", zeroDateOption=" + zeroDateOption + ", user='" + user + "', password=" + password +
-            ", database='" + database + "', createDatabaseIfNotExist=" + createDatabaseIfNotExist +
-            ", preferPrepareStatement=" + preferPrepareStatement +
-            ", sessionVariables=" + sessionVariables +
-            ", lockWaitTimeout=" + lockWaitTimeout +
-            ", statementTimeout=" + statementTimeout +
-            ", loadLocalInfilePath=" + loadLocalInfilePath +
-            ", localInfileBufferSize=" + localInfileBufferSize +
-            ", queryCacheSize=" + queryCacheSize +
-            ", prepareCacheSize=" + prepareCacheSize +
-            ", compressionAlgorithms=" + compressionAlgorithms +
-            ", zstdCompressionLevel=" + zstdCompressionLevel +
-            ", loopResources=" + loopResources +
-            ", extensions=" + extensions + ", passwordPublisher=" + passwordPublisher +
-            ", resolver=" + resolver +
-            '}';
+                ", extensions=" + extensions +
+                ", passwordPublisher=" + passwordPublisher +
+                ", resolver=" + resolver;
     }
 
     /**

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
@@ -370,8 +370,8 @@ public final class MySqlConnectionConfiguration {
     @Override
     public String toString() {
         return "MySqlConnectionConfiguration{" +
-                (isHost ? "host='" + domain + "', port=" + port + ", ssl=" + ssl + 
-                          ", tcpNoDelay=" + tcpNoDelay + ", tcpKeepAlive=" + tcpKeepAlive : 
+                (isHost ? "host='" + domain + "', port=" + port + ", ssl=" + ssl +
+                          ", tcpNoDelay=" + tcpNoDelay + ", tcpKeepAlive=" + tcpKeepAlive :
                         "unixSocket='" + domain + "'") +
                 buildCommonToStringPart() +
                 '}';

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
@@ -370,7 +370,9 @@ public final class MySqlConnectionConfiguration {
     @Override
     public String toString() {
         return "MySqlConnectionConfiguration{" +
-                (isHost ? "host='" + domain + "', port=" + port + ", ssl=" + ssl : "unixSocket='" + domain + "'") +
+                (isHost ? "host='" + domain + "', port=" + port + ", ssl=" + ssl + 
+                          ", tcpNoDelay=" + tcpNoDelay + ", tcpKeepAlive=" + tcpKeepAlive : 
+                        "unixSocket='" + domain + "'") +
                 buildCommonToStringPart() +
                 '}';
     }

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
@@ -22,6 +22,7 @@ import io.asyncer.r2dbc.mysql.constant.ZeroDateOption;
 import io.asyncer.r2dbc.mysql.extension.Extension;
 import io.asyncer.r2dbc.mysql.internal.util.InternalArrays;
 import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.resolver.AddressResolverGroup;
 import org.jetbrains.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.netty.resources.LoopResources;
@@ -127,6 +128,8 @@ public final class MySqlConnectionConfiguration {
     @Nullable
     private final Publisher<String> passwordPublisher;
 
+    private final AddressResolverGroup<?> resolver;
+
     private MySqlConnectionConfiguration(
         boolean isHost, String domain, int port, MySqlSslConfiguration ssl,
         boolean tcpKeepAlive, boolean tcpNoDelay, @Nullable Duration connectTimeout,
@@ -141,7 +144,8 @@ public final class MySqlConnectionConfiguration {
         int queryCacheSize, int prepareCacheSize,
         Set<CompressionAlgorithm> compressionAlgorithms, int zstdCompressionLevel,
         @Nullable LoopResources loopResources,
-        Extensions extensions, @Nullable Publisher<String> passwordPublisher
+        Extensions extensions, @Nullable Publisher<String> passwordPublisher,
+        @Nullable AddressResolverGroup<?> resolver
     ) {
         this.isHost = isHost;
         this.domain = domain;
@@ -171,6 +175,7 @@ public final class MySqlConnectionConfiguration {
         this.loopResources = loopResources == null ? TcpResources.get() : loopResources;
         this.extensions = extensions;
         this.passwordPublisher = passwordPublisher;
+        this.resolver = resolver;
     }
 
     /**
@@ -299,6 +304,11 @@ public final class MySqlConnectionConfiguration {
     @Nullable
     Publisher<String> getPasswordPublisher() {
         return passwordPublisher;
+    }
+
+    @Nullable
+    AddressResolverGroup<?> getResolver() {
+        return resolver;
     }
 
     @Override
@@ -494,6 +504,9 @@ public final class MySqlConnectionConfiguration {
         @Nullable
         private Publisher<String> passwordPublisher;
 
+        @Nullable
+        private AddressResolverGroup<?> resolver;
+
         /**
          * Builds an immutable {@link MySqlConnectionConfiguration} with current options.
          *
@@ -528,7 +541,7 @@ public final class MySqlConnectionConfiguration {
                 loadLocalInfilePath,
                 localInfileBufferSize, queryCacheSize, prepareCacheSize,
                 compressionAlgorithms, zstdCompressionLevel, loopResources,
-                Extensions.from(extensions, autodetectExtensions), passwordPublisher);
+                Extensions.from(extensions, autodetectExtensions), passwordPublisher, resolver);
         }
 
         /**
@@ -1153,6 +1166,11 @@ public final class MySqlConnectionConfiguration {
          */
         public Builder passwordPublisher(Publisher<String> passwordPublisher) {
             this.passwordPublisher = passwordPublisher;
+            return this;
+        }
+
+        public Builder resolver(AddressResolverGroup<?> resolver) {
+            this.resolver = resolver;
             return this;
         }
 

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
@@ -128,6 +128,7 @@ public final class MySqlConnectionConfiguration {
     @Nullable
     private final Publisher<String> passwordPublisher;
 
+    @Nullable
     private final AddressResolverGroup<?> resolver;
 
     private MySqlConnectionConfiguration(

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
@@ -348,7 +348,8 @@ public final class MySqlConnectionConfiguration {
             zstdCompressionLevel == that.zstdCompressionLevel &&
             Objects.equals(loopResources, that.loopResources) &&
             extensions.equals(that.extensions) &&
-            Objects.equals(passwordPublisher, that.passwordPublisher);
+            Objects.equals(passwordPublisher, that.passwordPublisher) &&
+            Objects.equals(resolver, that.resolver);
     }
 
     @Override
@@ -363,7 +364,7 @@ public final class MySqlConnectionConfiguration {
             loadLocalInfilePath, localInfileBufferSize,
             queryCacheSize, prepareCacheSize,
             compressionAlgorithms, zstdCompressionLevel,
-            loopResources, extensions, passwordPublisher);
+            loopResources, extensions, passwordPublisher, resolver);
     }
 
     @Override
@@ -387,7 +388,9 @@ public final class MySqlConnectionConfiguration {
                 ", compressionAlgorithms=" + compressionAlgorithms +
                 ", zstdCompressionLevel=" + zstdCompressionLevel +
                 ", loopResources=" + loopResources +
-                ", extensions=" + extensions + ", passwordPublisher=" + passwordPublisher + '}';
+                ", extensions=" + extensions + ", passwordPublisher=" + passwordPublisher +
+                ", resolver=" + resolver +
+                '}';
         }
 
         return "MySqlConnectionConfiguration{unixSocket='" + domain +
@@ -408,7 +411,9 @@ public final class MySqlConnectionConfiguration {
             ", compressionAlgorithms=" + compressionAlgorithms +
             ", zstdCompressionLevel=" + zstdCompressionLevel +
             ", loopResources=" + loopResources +
-            ", extensions=" + extensions + ", passwordPublisher=" + passwordPublisher + '}';
+            ", extensions=" + extensions + ", passwordPublisher=" + passwordPublisher +
+            ", resolver=" + resolver +
+            '}';
     }
 
     /**
@@ -1170,6 +1175,16 @@ public final class MySqlConnectionConfiguration {
             return this;
         }
 
+        /**
+         * Sets the {@link AddressResolverGroup} for resolving host addresses.
+         * <p>
+         * This can be used to customize the DNS resolution mechanism, which is particularly useful in environments
+         * with specific DNS configuration needs or where a custom DNS resolver is required.
+         *
+         * @param resolver the resolver group to use for host address resolution.
+         * @return this {@link Builder}.
+         * @since 1.2.0
+         */
         public Builder resolver(AddressResolverGroup<?> resolver) {
             this.resolver = resolver;
             return this;

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactory.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactory.java
@@ -147,7 +147,8 @@ public final class MySqlConnectionFactory implements ConnectionFactory {
             configuration.isTcpNoDelay(),
             context,
             configuration.getConnectTimeout(),
-            configuration.getLoopResources()
+            configuration.getLoopResources(),
+            configuration.getResolver()
         )).flatMap(client -> {
             // Lazy init database after handshake/login
             boolean deferDatabase = configuration.isCreateDatabaseIfNotExist();

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
@@ -401,6 +401,7 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
             .to(builder::loopResources);
         mapper.optional(PASSWORD_PUBLISHER).as(Publisher.class)
             .to(builder::passwordPublisher);
+        mapper.optional(RESOLVER).as(AddressResolverGroup.class);
         mapper.optional(SESSION_VARIABLES).asArray(
             String[].class,
             Function.identity(),

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
@@ -20,6 +20,7 @@ import io.asyncer.r2dbc.mysql.constant.CompressionAlgorithm;
 import io.asyncer.r2dbc.mysql.constant.SslMode;
 import io.asyncer.r2dbc.mysql.constant.ZeroDateOption;
 import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.resolver.AddressResolverGroup;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.ConnectionFactoryProvider;
@@ -307,6 +308,17 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
      * valid for 15 minutes, and this token will be used as password.
      */
     public static final Option<Publisher<String>> PASSWORD_PUBLISHER = Option.valueOf("passwordPublisher");
+
+    /**
+     * Option to set the {@link AddressResolverGroup} for resolving host addresses.
+     * <p>
+     * This can be used to customize the DNS resolution mechanism, which is particularly useful in environments
+     * with specific DNS configuration needs or where a custom DNS resolver is required.
+     * <p>
+     *
+     * @since 1.2.0
+     */
+    public static final Option<AddressResolverGroup<?>> RESOLVER = Option.valueOf("resolver");
 
     @Override
     public ConnectionFactory create(ConnectionFactoryOptions options) {

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
@@ -401,7 +401,8 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
             .to(builder::loopResources);
         mapper.optional(PASSWORD_PUBLISHER).as(Publisher.class)
             .to(builder::passwordPublisher);
-        mapper.optional(RESOLVER).as(AddressResolverGroup.class);
+        mapper.optional(RESOLVER).as(AddressResolverGroup.class)
+            .to(builder::resolver);
         mapper.optional(SESSION_VARIABLES).asArray(
             String[].class,
             Function.identity(),

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/client/Client.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/client/Client.java
@@ -133,7 +133,7 @@ public interface Client {
      */
     static Mono<Client> connect(MySqlSslConfiguration ssl, SocketAddress address, boolean tcpKeepAlive,
         boolean tcpNoDelay, ConnectionContext context, @Nullable Duration connectTimeout,
-        LoopResources loopResources, @Nullable AddressResolverGroup<?> resolverGroup) {
+        LoopResources loopResources, @Nullable AddressResolverGroup<?> resolver) {
         requireNonNull(ssl, "ssl must not be null");
         requireNonNull(address, "address must not be null");
         requireNonNull(context, "context must not be null");
@@ -151,8 +151,8 @@ public interface Client {
             tcpClient = tcpClient.option(ChannelOption.TCP_NODELAY, tcpNoDelay);
         }
 
-        if (resolverGroup != null) {
-            tcpClient = tcpClient.resolver(resolverGroup);
+        if (resolver != null) {
+            tcpClient = tcpClient.resolver(resolver);
         }
 
         return tcpClient.remoteAddress(() -> address).connect()

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/client/Client.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/client/Client.java
@@ -22,6 +22,7 @@ import io.asyncer.r2dbc.mysql.message.client.ClientMessage;
 import io.asyncer.r2dbc.mysql.message.server.ServerMessage;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelOption;
+import io.netty.resolver.AddressResolverGroup;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.jetbrains.annotations.Nullable;
@@ -132,7 +133,7 @@ public interface Client {
      */
     static Mono<Client> connect(MySqlSslConfiguration ssl, SocketAddress address, boolean tcpKeepAlive,
         boolean tcpNoDelay, ConnectionContext context, @Nullable Duration connectTimeout,
-        LoopResources loopResources) {
+        LoopResources loopResources, @Nullable AddressResolverGroup<?> resolverGroup) {
         requireNonNull(ssl, "ssl must not be null");
         requireNonNull(address, "address must not be null");
         requireNonNull(context, "context must not be null");
@@ -148,6 +149,10 @@ public interface Client {
         if (address instanceof InetSocketAddress) {
             tcpClient = tcpClient.option(ChannelOption.SO_KEEPALIVE, tcpKeepAlive);
             tcpClient = tcpClient.option(ChannelOption.TCP_NODELAY, tcpNoDelay);
+        }
+
+        if (resolverGroup != null) {
+            tcpClient = tcpClient.resolver(resolverGroup);
         }
 
         return tcpClient.remoteAddress(() -> address).connect()

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfigurationTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfigurationTest.java
@@ -22,6 +22,8 @@ import io.asyncer.r2dbc.mysql.constant.TlsVersions;
 import io.asyncer.r2dbc.mysql.constant.ZeroDateOption;
 import io.asyncer.r2dbc.mysql.extension.Extension;
 import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.resolver.AddressResolverGroup;
+import io.netty.resolver.DefaultAddressResolverGroup;
 import org.assertj.core.api.ObjectAssert;
 import org.assertj.core.api.ThrowableTypeAssert;
 import org.jetbrains.annotations.Nullable;
@@ -205,6 +207,19 @@ class MySqlConnectionConfigurationTest {
             .as(StepVerifier::create)
             .expectNext("123456")
             .verifyComplete();
+    }
+
+    @Test
+    void validResolver() {
+        final AddressResolverGroup<?> resolver = DefaultAddressResolverGroup.INSTANCE;
+        AddressResolverGroup<?> resolverGroup = MySqlConnectionConfiguration.builder()
+                .host(HOST)
+                .user(USER)
+                .resolver(resolver)
+                .autodetectExtensions(false)
+                .build()
+                .getResolver();
+        assertThat(resolverGroup).isSameAs(resolver);
     }
 
     private static MySqlConnectionConfiguration unixSocketSslMode(SslMode sslMode) {

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProviderTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProviderTest.java
@@ -20,6 +20,8 @@ import io.asyncer.r2dbc.mysql.constant.CompressionAlgorithm;
 import io.asyncer.r2dbc.mysql.constant.SslMode;
 import io.asyncer.r2dbc.mysql.constant.ZeroDateOption;
 import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.resolver.AddressResolverGroup;
+import io.netty.resolver.DefaultAddressResolverGroup;
 import io.r2dbc.spi.ConnectionFactories;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.Option;
@@ -50,6 +52,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.asyncer.r2dbc.mysql.MySqlConnectionFactoryProvider.PASSWORD_PUBLISHER;
+import static io.asyncer.r2dbc.mysql.MySqlConnectionFactoryProvider.RESOLVER;
 import static io.asyncer.r2dbc.mysql.MySqlConnectionFactoryProvider.USE_SERVER_PREPARE_STATEMENT;
 import static io.r2dbc.spi.ConnectionFactoryOptions.CONNECT_TIMEOUT;
 import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
@@ -448,6 +451,19 @@ class MySqlConnectionFactoryProviderTest {
             .option(HOST, "127.0.0.1")
             .option(USER, "root")
             .option(PASSWORD_PUBLISHER, passwordSupplier)
+            .build();
+
+        assertThat(ConnectionFactories.get(options)).isExactlyInstanceOf(MySqlConnectionFactory.class);
+    }
+
+    @Test
+    void validResolver() {
+        final AddressResolverGroup<?> resolver = DefaultAddressResolverGroup.INSTANCE;
+        ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
+            .option(DRIVER, "mysql")
+            .option(HOST, "127.0.0.1")
+            .option(USER, "root")
+            .option(RESOLVER, resolver)
             .build();
 
         assertThat(ConnectionFactories.get(options)).isExactlyInstanceOf(MySqlConnectionFactory.class);


### PR DESCRIPTION
Motivation:
Currently,`AddressResolverGroup` can't be configured. The DnsResolver default start address listen to "0.0.0.0", which may have some security risks.
also see https://github.com/netty/netty/pull/11061

Modification:
Add `AddressResolverGroup` in Client's connect method