### PR TITLE
[WIP]Support `tinyInt1isBit`

### DIFF
--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/ConnectionContext.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/ConnectionContext.java
@@ -53,6 +53,8 @@ public final class ConnectionContext implements CodecContext {
 
     private final boolean preserveInstants;
 
+    private final boolean tinyInt1isBit;
+
     private int connectionId = -1;
 
     private ServerVersion serverVersion = NONE_VERSION;
@@ -104,16 +106,18 @@ public final class ConnectionContext implements CodecContext {
     private volatile short serverStatuses = ServerStatuses.AUTO_COMMIT;
 
     ConnectionContext(
-        ZeroDateOption zeroDateOption,
-        @Nullable Path localInfilePath,
-        int localInfileBufferSize,
-        boolean preserveInstants,
-        @Nullable ZoneId timeZone
+            ZeroDateOption zeroDateOption,
+            @Nullable Path localInfilePath,
+            int localInfileBufferSize,
+            boolean preserveInstants,
+            boolean tinyInt1isBit,
+            @Nullable ZoneId timeZone
     ) {
         this.zeroDateOption = requireNonNull(zeroDateOption, "zeroDateOption must not be null");
         this.localInfilePath = localInfilePath;
         this.localInfileBufferSize = localInfileBufferSize;
         this.preserveInstants = preserveInstants;
+        this.tinyInt1isBit = tinyInt1isBit;
         this.timeZone = timeZone;
     }
 
@@ -332,5 +336,10 @@ public final class ConnectionContext implements CodecContext {
         short serverStatuses = this.serverStatuses;
         return (serverStatuses & ServerStatuses.IN_TRANSACTION) == 0 &&
             (serverStatuses & ServerStatuses.AUTO_COMMIT) != 0;
+    }
+
+    @Override
+    public boolean isTinyInt1isBit() {
+        return tinyInt1isBit;
     }
 }

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
@@ -1185,11 +1185,15 @@ public final class MySqlConnectionConfiguration {
         }
 
         /**
-         * Sets
-         * @param tinyInt1isBit
-         * @return
+         * Option to set the {@link AddressResolverGroup} for resolving host addresses.
+         * <p>
+         * This can be used to customize the DNS resolution mechanism, which is particularly useful in environments
+         * with specific DNS configuration needs or where a custom DNS resolver is required.
+         *
+         * @param tinyInt1isBit true to treat TINYINT(1), BIT(1) as Boolean, false otherwise.
+         * @return this {@link Builder}
          */
-        public Builder tinyInt1isBit(boolean tinyInt1isBit) {
+        public Builder tinyInt1isBit(final boolean tinyInt1isBit) {
             this.tinyInt1isBit = tinyInt1isBit;
             return this;
         }

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
@@ -131,22 +131,24 @@ public final class MySqlConnectionConfiguration {
     @Nullable
     private final AddressResolverGroup<?> resolver;
 
+    private final boolean tinyInt1isBit;
+
     private MySqlConnectionConfiguration(
-        boolean isHost, String domain, int port, MySqlSslConfiguration ssl,
-        boolean tcpKeepAlive, boolean tcpNoDelay, @Nullable Duration connectTimeout,
-        ZeroDateOption zeroDateOption,
-        boolean preserveInstants,
-        String connectionTimeZone,
-        boolean forceConnectionTimeZoneToSession,
-        String user, @Nullable CharSequence password, @Nullable String database,
-        boolean createDatabaseIfNotExist, @Nullable Predicate<String> preferPrepareStatement,
-        List<String> sessionVariables, @Nullable Duration lockWaitTimeout, @Nullable Duration statementTimeout,
-        @Nullable Path loadLocalInfilePath, int localInfileBufferSize,
-        int queryCacheSize, int prepareCacheSize,
-        Set<CompressionAlgorithm> compressionAlgorithms, int zstdCompressionLevel,
-        @Nullable LoopResources loopResources,
-        Extensions extensions, @Nullable Publisher<String> passwordPublisher,
-        @Nullable AddressResolverGroup<?> resolver
+            boolean isHost, String domain, int port, MySqlSslConfiguration ssl,
+            boolean tcpKeepAlive, boolean tcpNoDelay, @Nullable Duration connectTimeout,
+            ZeroDateOption zeroDateOption,
+            boolean preserveInstants,
+            String connectionTimeZone,
+            boolean forceConnectionTimeZoneToSession,
+            String user, @Nullable CharSequence password, @Nullable String database,
+            boolean createDatabaseIfNotExist, @Nullable Predicate<String> preferPrepareStatement,
+            List<String> sessionVariables, @Nullable Duration lockWaitTimeout, @Nullable Duration statementTimeout,
+            @Nullable Path loadLocalInfilePath, int localInfileBufferSize,
+            int queryCacheSize, int prepareCacheSize,
+            Set<CompressionAlgorithm> compressionAlgorithms, int zstdCompressionLevel,
+            @Nullable LoopResources loopResources,
+            Extensions extensions, @Nullable Publisher<String> passwordPublisher,
+            @Nullable AddressResolverGroup<?> resolver, boolean tinyInt1isBit
     ) {
         this.isHost = isHost;
         this.domain = domain;
@@ -177,6 +179,7 @@ public final class MySqlConnectionConfiguration {
         this.extensions = extensions;
         this.passwordPublisher = passwordPublisher;
         this.resolver = resolver;
+        this.tinyInt1isBit = tinyInt1isBit;
     }
 
     /**
@@ -310,6 +313,10 @@ public final class MySqlConnectionConfiguration {
     @Nullable
     AddressResolverGroup<?> getResolver() {
         return resolver;
+    }
+
+    boolean getTinyInt1isBit() {
+        return tinyInt1isBit;
     }
 
     @Override
@@ -498,6 +505,8 @@ public final class MySqlConnectionConfiguration {
         @Nullable
         private AddressResolverGroup<?> resolver;
 
+        private boolean tinyInt1isBit = true;
+
         /**
          * Builds an immutable {@link MySqlConnectionConfiguration} with current options.
          *
@@ -532,7 +541,7 @@ public final class MySqlConnectionConfiguration {
                 loadLocalInfilePath,
                 localInfileBufferSize, queryCacheSize, prepareCacheSize,
                 compressionAlgorithms, zstdCompressionLevel, loopResources,
-                Extensions.from(extensions, autodetectExtensions), passwordPublisher, resolver);
+                Extensions.from(extensions, autodetectExtensions), passwordPublisher, resolver, tinyInt1isBit);
         }
 
         /**
@@ -1172,6 +1181,16 @@ public final class MySqlConnectionConfiguration {
          */
         public Builder resolver(AddressResolverGroup<?> resolver) {
             this.resolver = resolver;
+            return this;
+        }
+
+        /**
+         * Sets
+         * @param tinyInt1isBit
+         * @return
+         */
+        public Builder tinyInt1isBit(boolean tinyInt1isBit) {
+            this.tinyInt1isBit = tinyInt1isBit;
             return this;
         }
 

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactory.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactory.java
@@ -138,6 +138,7 @@ public final class MySqlConnectionFactory implements ConnectionFactory {
                 configuration.getLoadLocalInfilePath(),
                 configuration.getLocalInfileBufferSize(),
                 configuration.isPreserveInstants(),
+                configuration.getTinyInt1isBit(),
                 connectionTimeZone
             );
         }).flatMap(context -> Client.connect(

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
@@ -321,9 +321,12 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
     public static final Option<AddressResolverGroup<?>> RESOLVER = Option.valueOf("resolver");
 
     /**
+     * Option to treat TINYINT(1), BIT(1) as Boolean.
+     * <p>
+     * By setting this option, you can ensure that the driver interprets TINYINT(1), BIT(1) columns as boolean
+     * values instead of numeric values.
      *
-     * @param options
-     * @return
+     * @since 1.3.0
      */
     public static final Option<Boolean> TINY_INT_1_IS_BIT = Option.valueOf("tinyInt1isBit");
 

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
@@ -320,6 +320,13 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
      */
     public static final Option<AddressResolverGroup<?>> RESOLVER = Option.valueOf("resolver");
 
+    /**
+     *
+     * @param options
+     * @return
+     */
+    public static final Option<Boolean> TINY_INT_1_IS_BIT = Option.valueOf("tinyInt1isBit");
+
     @Override
     public ConnectionFactory create(ConnectionFactoryOptions options) {
         requireNonNull(options, "connectionFactoryOptions must not be null");
@@ -413,6 +420,8 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
             .to(builder::lockWaitTimeout);
         mapper.optional(STATEMENT_TIMEOUT).as(Duration.class, Duration::parse)
             .to(builder::statementTimeout);
+        mapper.optional(TINY_INT_1_IS_BIT).asBoolean()
+                .to(builder::tinyInt1isBit);
 
         return builder.build();
     }

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/BooleanCodec.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/BooleanCodec.java
@@ -54,7 +54,7 @@ final class BooleanCodec extends AbstractPrimitiveCodec<Boolean> {
     @Override
     public boolean doCanDecode(MySqlReadableMetadata metadata) {
         MySqlType type = metadata.getType();
-        return (type == MySqlType.BIT || type == MySqlType.TINYINT) &&
+        return (type == MySqlType.BIT || type == MySqlType.TINYINT || type == MySqlType.TINYINT_UNSIGNED) &&
             Integer.valueOf(1).equals(metadata.getPrecision());
     }
 

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/CodecContext.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/CodecContext.java
@@ -35,6 +35,9 @@ public interface CodecContext {
      */
     boolean isPreserveInstants();
 
+
+    boolean isTinyInt1isBit();
+
     /**
      * Gets the {@link ZoneId} of connection.
      *

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/ConnectionContextTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/ConnectionContextTest.java
@@ -39,7 +39,7 @@ public class ConnectionContextTest {
             String id = i < 0 ? "UTC" + i : "UTC+" + i;
             ConnectionContext context = new ConnectionContext(
                 ZeroDateOption.USE_NULL, null,
-                8192, true, ZoneId.of(id));
+                8192, true, true, ZoneId.of(id));
 
             assertThat(context.getTimeZone()).isEqualTo(ZoneId.of(id));
         }
@@ -48,7 +48,7 @@ public class ConnectionContextTest {
     @Test
     void setTwiceTimeZone() {
         ConnectionContext context = new ConnectionContext(ZeroDateOption.USE_NULL, null,
-            8192, true, null);
+            8192, true, true, null);
 
         context.initSession(
             Caches.createPrepareCache(0),
@@ -70,7 +70,7 @@ public class ConnectionContextTest {
     @Test
     void badSetTimeZone() {
         ConnectionContext context = new ConnectionContext(ZeroDateOption.USE_NULL, null,
-            8192, true, ZoneId.systemDefault());
+            8192, true, true, ZoneId.systemDefault());
         assertThatIllegalStateException().isThrownBy(() -> context.initSession(
             Caches.createPrepareCache(0),
             IsolationLevel.REPEATABLE_READ,
@@ -91,7 +91,7 @@ public class ConnectionContextTest {
 
     public static ConnectionContext mock(boolean isMariaDB, ZoneId zoneId) {
         ConnectionContext context = new ConnectionContext(ZeroDateOption.USE_NULL, null,
-            8192, true, zoneId);
+            8192, true, true, zoneId);
 
         context.initHandshake(1, ServerVersion.parse(isMariaDB ? "11.2.22.MOCKED" : "8.0.11.MOCKED"),
             Capability.of(~(isMariaDB ? 1 : 0)));


### PR DESCRIPTION
Motivation:
Currently, the R2DBC MySQL connector does not  support the `tinyInt1isBit` MySQL parameter.

Modifications:
Updated the mapping of `TINYINT(1)` or `BIT(1)` values to boolean based on the `tinyInt1isBit` parameter.

Result:
Properly supports the `tinyInt1isBit` parameter.
Resolves #277

TODO
- [x] javadoc
- [ ] unit tests
- [ ] int tests
- [x] wiki