### PR TITLE
Support MySQL 8.4 and 9.0

### DIFF
--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        mysql-version: [ 5.5, 5.6.45, 5.6, 5.7.28, 5.7, 8.0, 8.1, 8.2, 8.3]
+        mysql-version: [ 5.5, 5.6.45, 5.6, 5.7.28, 5.7, 8.0, 8.1, 8.2, 8.3, 8.4, 9.0]
     name: Integration test with MySQL ${{ matrix.mysql-version }}
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ This driver provides the following features:
 ![MySQL 8.0 status](https://img.shields.io/badge/MySQL%208.0-pass-blue)
 ![MySQL 8.1 status](https://img.shields.io/badge/MySQL%208.1-pass-blue)
 ![MySQL 8.2 status](https://img.shields.io/badge/MySQL%208.2-pass-blue)
+![MySQL 8.3 status](https://img.shields.io/badge/MySQL%208.3-pass-blue)
+![MySQL 8.4 status](https://img.shields.io/badge/MySQL%208.4-pass-blue)
+![MySQL 9.0 status](https://img.shields.io/badge/MySQL%209.0-pass-blue)
 ![MariaDB 10.6 status](https://img.shields.io/badge/MariaDB%2010.6-pass-blue)
 ![MariaDB 10.11 status](https://img.shields.io/badge/MariaDB%2010.11-pass-blue)
 


### PR DESCRIPTION
Motivation:
Add compatibility for the newer MySQL versions 8.4 and 9.0 to ensure the connector works with the latest MySQL features and improvements.

Modifications:
- Added tests to verify functionality with MySQL 8.4 and 9.0.

Result:
Ensures compatibility with MySQL 8.4 and 9.0.
