### PR TITLE
Implemented relaxed conversion logic for BooleanCodec

### DIFF
--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/BooleanCodec.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/BooleanCodec.java
@@ -24,6 +24,7 @@ import io.asyncer.r2dbc.mysql.api.MySqlReadableMetadata;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import io.r2dbc.spi.R2dbcNonTransientResourceException;
 import reactor.core.publisher.Mono;
 
 /**
@@ -55,7 +56,8 @@ final class BooleanCodec extends AbstractPrimitiveCodec<Boolean> {
             } else if (s.equalsIgnoreCase("N") || s.equalsIgnoreCase("no") ||
             s.equalsIgnoreCase("F") || s.equalsIgnoreCase("false")) {
                 return createFromLong(0);
-            } else if (s.matches("-?\\d*\\.\\d*") || s.matches("-?\\d*\\.\\d+[eE]-?\\d+")) {
+            } else if (s.matches("-?\\d*\\.\\d*") || s.matches("-?\\d*\\.\\d+[eE]-?\\d+")
+            || s.matches("-?\\d*[eE]-?\\d+")) {
                 return createFromDouble(Double.parseDouble(s));
             } else if (s.matches("-?\\d+")) {
                 if (!CodecUtils.isGreaterThanLongMax(s)) {
@@ -63,7 +65,8 @@ final class BooleanCodec extends AbstractPrimitiveCodec<Boolean> {
                 }
                 return createFromBigInteger(new BigInteger(s));
             }
-            throw new IllegalArgumentException("Unable to interpret string: " + s);
+            throw new R2dbcNonTransientResourceException("The value '" + s + "' of type '" + dataType + 
+            "' cannot be encoded into a Boolean.", "22018");
         }
 
         return binary || dataType == MySqlType.BIT ? value.readBoolean() : value.readByte() != '0';

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/BooleanCodec.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/BooleanCodec.java
@@ -55,7 +55,7 @@ final class BooleanCodec extends AbstractPrimitiveCodec<Boolean> {
             } else if (s.equalsIgnoreCase("N") || s.equalsIgnoreCase("no") ||
             s.equalsIgnoreCase("F") || s.equalsIgnoreCase("false")) {
                 return createFromLong(0);
-            } else if (s.contains("e") || s.contains("E") || s.matches("-?\\d*\\.\\d*")) {
+            } else if (s.matches("-?\\d*\\.\\d*") || s.matches("-?\\d*\\.\\d+[eE]-?\\d+")) {
                 return createFromDouble(Double.parseDouble(s));
             } else if (s.matches("-?\\d+")) {
                 if (!CodecUtils.isGreaterThanLongMax(s)) {

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/BooleanCodec.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/BooleanCodec.java
@@ -65,7 +65,7 @@ final class BooleanCodec extends AbstractPrimitiveCodec<Boolean> {
             }
             throw new IllegalArgumentException("Unable to interpret string: " + s);
         }
-        
+
         return binary || dataType == MySqlType.BIT ? value.readBoolean() : value.readByte() != '0';
     }
 

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/BooleanCodec.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/BooleanCodec.java
@@ -46,10 +46,10 @@ final class BooleanCodec extends AbstractPrimitiveCodec<Boolean> {
 
         String s = value.toString(metadata.getCharCollation(context).getCharset());
 
-        if (s.equalsIgnoreCase("Y") || s.equalsIgnoreCase("yes") || 
+        if (s.equalsIgnoreCase("Y") || s.equalsIgnoreCase("yes") ||
         s.equalsIgnoreCase("T") || s.equalsIgnoreCase("true")) {
             return createFromLong(1);
-        } else if (s.equalsIgnoreCase("N") || s.equalsIgnoreCase("no") || 
+        } else if (s.equalsIgnoreCase("N") || s.equalsIgnoreCase("no") ||
         s.equalsIgnoreCase("F") || s.equalsIgnoreCase("false")) {
             return createFromLong(0);
         } else if (s.contains("e") || s.contains("E") || s.matches("-?\\d*\\.\\d*")) {

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/BooleanCodec.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/codec/BooleanCodec.java
@@ -65,7 +65,7 @@ final class BooleanCodec extends AbstractPrimitiveCodec<Boolean> {
                 }
                 return createFromBigInteger(new BigInteger(s));
             }
-            throw new R2dbcNonTransientResourceException("The value '" + s + "' of type '" + dataType + 
+            throw new R2dbcNonTransientResourceException("The value '" + s + "' of type '" + dataType +
             "' cannot be encoded into a Boolean.", "22018");
         }
 

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/codec/BooleanCodecTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/codec/BooleanCodecTest.java
@@ -20,6 +20,7 @@ import io.asyncer.r2dbc.mysql.ConnectionContextTest;
 import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.r2dbc.spi.R2dbcNonTransientException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -135,7 +136,7 @@ class BooleanCodecTest implements CodecTestSupport<Boolean> {
             .isEqualTo(false);
 
         assertThatThrownBy(() -> {codec.decode(d11.content(), d11.metadata(), Boolean.class, false, ConnectionContextTest.mock());})
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(R2dbcNonTransientException.class);
 
         assertThat(codec.decode(d12.content(), d12.metadata(), Boolean.class, false, ConnectionContextTest.mock()))
             .as("Decode failed, %s", d12)

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/codec/BooleanCodecTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/codec/BooleanCodecTest.java
@@ -73,9 +73,9 @@ class BooleanCodecTest implements CodecTestSupport<Boolean> {
         Decoding d4 = new Decoding(Unpooled.copiedBuffer("0", c), "0", MySqlType.VARCHAR);
         Decoding d5 = new Decoding(Unpooled.copiedBuffer("Y", c), "Y", MySqlType.VARCHAR);
         Decoding d6 = new Decoding(Unpooled.copiedBuffer("no", c), "no", MySqlType.VARCHAR);
-        Decoding d7 = new Decoding(Unpooled.copyDouble(26.57d), 26.57d, MySqlType.DOUBLE);
-        Decoding d8 = new Decoding(Unpooled.copyLong(-57L), -57L, MySqlType.TINYINT);
-        Decoding d9 = new Decoding(Unpooled.copyLong(100000L), 100000L, MySqlType.BIGINT);
+        Decoding d7 = new Decoding(Unpooled.copyDouble(26.57), 26.57, MySqlType.DOUBLE);
+        Decoding d8 = new Decoding(Unpooled.copyLong(-57), -57, MySqlType.TINYINT);
+        Decoding d9 = new Decoding(Unpooled.copyLong(100000), 100000, MySqlType.BIGINT);
         Decoding d10 = new Decoding(Unpooled.copiedBuffer("-12345678901234567890", c),
         "-12345678901234567890", MySqlType.VARCHAR);
         Decoding d11 = new Decoding(Unpooled.copiedBuffer("Banana", c), "Banana", MySqlType.VARCHAR);

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/codec/BooleanCodecTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/codec/BooleanCodecTest.java
@@ -22,6 +22,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.charset.Charset;
 import java.util.Arrays;
@@ -70,6 +71,14 @@ class BooleanCodecTest implements CodecTestSupport<Boolean> {
         Decoding d2 = new Decoding(Unpooled.copiedBuffer("false", c), "false", MySqlType.VARCHAR);
         Decoding d3 = new Decoding(Unpooled.copiedBuffer("1", c), "1", MySqlType.VARCHAR);
         Decoding d4 = new Decoding(Unpooled.copiedBuffer("0", c), "0", MySqlType.VARCHAR);
+        Decoding d5 = new Decoding(Unpooled.copiedBuffer("Y", c), "Y", MySqlType.VARCHAR);
+        Decoding d6 = new Decoding(Unpooled.copiedBuffer("no", c), "no", MySqlType.VARCHAR);
+        Decoding d7 = new Decoding(Unpooled.copyDouble(26.57d), 26.57d, MySqlType.DOUBLE);
+        Decoding d8 = new Decoding(Unpooled.copyLong(-57L), -57L, MySqlType.TINYINT);
+        Decoding d9 = new Decoding(Unpooled.copyLong(100000L), 100000L, MySqlType.BIGINT);
+        Decoding d10 = new Decoding(Unpooled.copiedBuffer("-12345678901234567890", c),
+        "-12345678901234567890", MySqlType.VARCHAR);
+        Decoding d11 = new Decoding(Unpooled.copiedBuffer("Banana", c), "Banana", MySqlType.VARCHAR);
 
         assertThat(codec.decode(d1.content(), d1.metadata(), Boolean.class, false, ConnectionContextTest.mock()))
             .as("Decode failed, %s", d1)
@@ -86,5 +95,32 @@ class BooleanCodecTest implements CodecTestSupport<Boolean> {
         assertThat(codec.decode(d4.content(), d4.metadata(), Boolean.class, false, ConnectionContextTest.mock()))
             .as("Decode failed, %s", d4)
             .isEqualTo(false);
+
+        assertThat(codec.decode(d5.content(), d5.metadata(), Boolean.class, false, ConnectionContextTest.mock()))
+            .as("Decode failed, %s", d5)
+            .isEqualTo(true);
+
+        assertThat(codec.decode(d6.content(), d6.metadata(), Boolean.class, false, ConnectionContextTest.mock()))
+            .as("Decode failed, %s", d6)
+            .isEqualTo(false);
+
+        assertThat(codec.decode(d7.content(), d7.metadata(), Boolean.class, false, ConnectionContextTest.mock()))
+            .as("Decode failed, %s", d7)
+            .isEqualTo(true);
+
+        assertThat(codec.decode(d8.content(), d8.metadata(), Boolean.class, false, ConnectionContextTest.mock()))
+            .as("Decode failed, %s", d8)
+            .isEqualTo(false);
+
+        assertThat(codec.decode(d9.content(), d9.metadata(), Boolean.class, false, ConnectionContextTest.mock()))
+            .as("Decode failed, %s", d9)
+            .isEqualTo(true);
+
+        assertThat(codec.decode(d10.content(), d10.metadata(), Boolean.class, false, ConnectionContextTest.mock()))
+            .as("Decode failed, %s", d10)
+            .isEqualTo(false);
+
+        assertThatThrownBy(() -> {codec.decode(d11.content(), d11.metadata(), Boolean.class, false, ConnectionContextTest.mock());})
+        .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/codec/BooleanCodecTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/codec/BooleanCodecTest.java
@@ -90,6 +90,9 @@ class BooleanCodecTest implements CodecTestSupport<Boolean> {
         Decoding d14 = new Decoding(Unpooled.copyDouble(26.57d), 26.57d, MySqlType.DOUBLE);
         Decoding d15 = new Decoding(Unpooled.copiedBuffer(bOne), bOne, MySqlType.TINYINT);
         Decoding d16 = new Decoding(Unpooled.copiedBuffer(bZero), bZero, MySqlType.TINYINT);
+        Decoding d17 = new Decoding(Unpooled.copiedBuffer("1e4", c), "1e4", MySqlType.VARCHAR);
+        Decoding d18 = new Decoding(Unpooled.copiedBuffer("-1.34e10", c), "-1.34e10", MySqlType.VARCHAR);
+        Decoding d19 = new Decoding(Unpooled.copiedBuffer("-0", c), "-0", MySqlType.VARCHAR);
 
         assertThat(codec.decode(d1.content(), d1.metadata(), Boolean.class, false, ConnectionContextTest.mock()))
             .as("Decode failed, %s", d1)
@@ -151,7 +154,19 @@ class BooleanCodecTest implements CodecTestSupport<Boolean> {
             .isEqualTo(true);
 
         assertThat(codec.decode(d16.content(), d16.metadata(), Boolean.class, true, ConnectionContextTest.mock()))
-            .as("Decode failed, %s", d14)
+            .as("Decode failed, %s", d16)
+            .isEqualTo(false);
+
+        assertThat(codec.decode(d17.content(), d17.metadata(), Boolean.class, false, ConnectionContextTest.mock()))
+            .as("Decode failed, %s", d17)
+            .isEqualTo(true);
+
+        assertThat(codec.decode(d18.content(), d18.metadata(), Boolean.class, false, ConnectionContextTest.mock()))
+            .as("Decode failed, %s", d18)
+            .isEqualTo(false);
+
+        assertThat(codec.decode(d19.content(), d19.metadata(), Boolean.class, false, ConnectionContextTest.mock()))
+            .as("Decode failed, %s", d19)
             .isEqualTo(false);
     }
 }

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/codec/BooleanCodecTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/codec/BooleanCodecTest.java
@@ -16,11 +16,17 @@
 
 package io.asyncer.r2dbc.mysql.codec;
 
+import io.asyncer.r2dbc.mysql.ConnectionContextTest;
+import io.asyncer.r2dbc.mysql.constant.MySqlType;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.nio.charset.Charset;
 import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link BooleanCodec}.
@@ -54,5 +60,31 @@ class BooleanCodecTest implements CodecTestSupport<Boolean> {
     @Override
     public ByteBuf sized(ByteBuf value) {
         return value;
+    }
+
+    @Test
+    void decodeString() {
+        Codec<Boolean> codec = getCodec();
+        Charset c = ConnectionContextTest.mock().getClientCollation().getCharset();
+        Decoding d1 = new Decoding(Unpooled.copiedBuffer("true", c), "true", MySqlType.VARCHAR);
+        Decoding d2 = new Decoding(Unpooled.copiedBuffer("false", c), "false", MySqlType.VARCHAR);
+        Decoding d3 = new Decoding(Unpooled.copiedBuffer("1", c), "1", MySqlType.VARCHAR);
+        Decoding d4 = new Decoding(Unpooled.copiedBuffer("0", c), "0", MySqlType.VARCHAR);
+
+        assertThat(codec.decode(d1.content(), d1.metadata(), Boolean.class, false, ConnectionContextTest.mock()))
+            .as("Decode failed, %s", d1)
+            .isEqualTo(true);
+
+        assertThat(codec.decode(d2.content(), d2.metadata(), Boolean.class, false, ConnectionContextTest.mock()))
+            .as("Decode failed, %s", d2)
+            .isEqualTo(false);
+
+        assertThat(codec.decode(d3.content(), d3.metadata(), Boolean.class, false, ConnectionContextTest.mock()))
+            .as("Decode failed, %s", d3)
+            .isEqualTo(true);
+
+        assertThat(codec.decode(d4.content(), d4.metadata(), Boolean.class, false, ConnectionContextTest.mock()))
+            .as("Decode failed, %s", d4)
+            .isEqualTo(false);
     }
 }


### PR DESCRIPTION
@jchrys #285 

Motivation:
To allow boolean values stored as strings in MySQL database such as "true", "false", "1" and "0" to be converted to their corresponding boolean values.

Modification:
BooleanCodec: Changed decode method to check if VARCHAR value is a boolean value. Changed doCanDecode to add VARCHAR.
BooleanCodecTest: Added decodeString test to ensure boolean values stored as strings are converted into the correct corresponding boolean values.

Result:
Boolean values stored as strings can now be converted to their corresponding boolean values. Drawbacks are that there could be a string column containing numeric data with values other than 0 or 1 and the column isn't used for storing boolean values at the same time the codec interprets the 0's and 1's as boolean. Only boolean values "true", "false", "1" and "0" are decoded, other possible types of boolean value strings haven't been included.  Also, doCanDecode states that the VARCHAR data type can be decoded but only a small subset of this data type can be decoded and it's not possible to highlight the conditions in the doCanDecode method.