### PR TITLE
feat: enable TcpClient metrics

### DIFF
--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactory.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactory.java
@@ -148,7 +148,8 @@ public final class MySqlConnectionFactory implements ConnectionFactory {
             context,
             configuration.getConnectTimeout(),
             configuration.getLoopResources(),
-            configuration.getResolver()
+            configuration.getResolver(),
+            configuration.isMetrics()
         )).flatMap(client -> {
             // Lazy init database after handshake/login
             boolean deferDatabase = configuration.isCreateDatabaseIfNotExist();

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProvider.java
@@ -320,6 +320,16 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
      */
     public static final Option<AddressResolverGroup<?>> RESOLVER = Option.valueOf("resolver");
 
+    /**
+     * Option to enable metrics to be collected and registered in Micrometer's globalRegistry
+     * with {@link reactor.netty.tcp.TcpClient#metrics(boolean)}. Defaults to {@code false}.
+     * <p>
+     * Note: It is required to add {@code io.micrometer.micrometer-core} dependency to classpath.
+     *
+     * @since 1.3.2
+     */
+    public static final Option<Boolean> METRICS = Option.valueOf("metrics");
+
     @Override
     public ConnectionFactory create(ConnectionFactoryOptions options) {
         requireNonNull(options, "connectionFactoryOptions must not be null");
@@ -413,6 +423,8 @@ public final class MySqlConnectionFactoryProvider implements ConnectionFactoryPr
             .to(builder::lockWaitTimeout);
         mapper.optional(STATEMENT_TIMEOUT).as(Duration.class, Duration::parse)
             .to(builder::statementTimeout);
+        mapper.optional(METRICS).asBoolean()
+            .to(builder::metrics);
 
         return builder.build();
     }

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/client/Client.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/client/Client.java
@@ -127,19 +127,21 @@ public interface Client {
      * @param context        the connection context
      * @param connectTimeout connect timeout, or {@code null} if it has no timeout
      * @param loopResources  the loop resources to use
+     * @param metrics        if enable the {@link TcpClient#metrics)}
      * @return A {@link Mono} that will emit a connected {@link Client}.
      * @throws IllegalArgumentException if {@code ssl}, {@code address} or {@code context} is {@code null}.
      * @throws ArithmeticException      if {@code connectTimeout} milliseconds overflow as an int
      */
     static Mono<Client> connect(MySqlSslConfiguration ssl, SocketAddress address, boolean tcpKeepAlive,
         boolean tcpNoDelay, ConnectionContext context, @Nullable Duration connectTimeout,
-        LoopResources loopResources, @Nullable AddressResolverGroup<?> resolver) {
+        LoopResources loopResources, @Nullable AddressResolverGroup<?> resolver, boolean metrics) {
         requireNonNull(ssl, "ssl must not be null");
         requireNonNull(address, "address must not be null");
         requireNonNull(context, "context must not be null");
 
         TcpClient tcpClient = TcpClient.newConnection()
-            .runOn(loopResources);
+            .runOn(loopResources)
+            .metrics(metrics);
 
         if (connectTimeout != null) {
             tcpClient = tcpClient.option(ChannelOption.CONNECT_TIMEOUT_MILLIS,

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfigurationTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfigurationTest.java
@@ -222,6 +222,19 @@ class MySqlConnectionConfigurationTest {
         assertThat(resolverGroup).isSameAs(resolver);
     }
 
+    @Test
+    void invalidMetrics() {
+        // throw exception when metrics true without micrometer-core dependency
+        assertThatIllegalArgumentException().isThrownBy(() ->
+            MySqlConnectionConfiguration
+                .builder()
+                .host(HOST)
+                .user(USER)
+                .metrics(true)
+                .build()
+        );
+    }
+
     private static MySqlConnectionConfiguration unixSocketSslMode(SslMode sslMode) {
         return MySqlConnectionConfiguration.builder()
             .unixSocket(UNIX_SOCKET)

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProviderTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionFactoryProviderTest.java
@@ -51,6 +51,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static io.asyncer.r2dbc.mysql.MySqlConnectionFactoryProvider.METRICS;
 import static io.asyncer.r2dbc.mysql.MySqlConnectionFactoryProvider.PASSWORD_PUBLISHER;
 import static io.asyncer.r2dbc.mysql.MySqlConnectionFactoryProvider.RESOLVER;
 import static io.asyncer.r2dbc.mysql.MySqlConnectionFactoryProvider.USE_SERVER_PREPARE_STATEMENT;
@@ -467,6 +468,18 @@ class MySqlConnectionFactoryProviderTest {
             .build();
 
         assertThat(ConnectionFactories.get(options)).isExactlyInstanceOf(MySqlConnectionFactory.class);
+    }
+
+    @Test
+    void invalidMetrics() {
+        // throw exception when metrics true without micrometer-core dependency
+        assertThatIllegalArgumentException().isThrownBy(() ->
+            ConnectionFactories.get(ConnectionFactoryOptions.builder()
+                .option(DRIVER, "mysql")
+                .option(HOST, "127.0.0.1")
+                .option(USER, "root")
+                .option(METRICS, true)
+                .build()));
     }
 
     @Test


### PR DESCRIPTION
Motivation:
cannot check if LoopResources event loop has pending tasks with metrics.

Modification:
add `TcpClient.metrics(true)` with if statements, check if micrometer is available.

Result:
expose the metrics of LoopResources including `reactor_netty_event_loop_pending_tasks`.
The following is a list of metrics exposed when the commit was applied (with default TcpResources)

```
reactor_netty_eventloop_pending_tasks{name="reactor-tcp-nio-4"} 0.0
reactor_netty_eventloop_pending_tasks{name="reactor-tcp-nio-5"} 0.0
reactor_netty_eventloop_pending_tasks{name="reactor-tcp-nio-6"} 0.0
reactor_netty_eventloop_pending_tasks{name="reactor-tcp-nio-7"} 0.0
reactor_netty_eventloop_pending_tasks{name="reactor-tcp-nio-8"} 0.0
reactor_netty_tcp_client_address_resolver_seconds_count{remote_address="localhost:64921",status="SUCCESS"} 100
reactor_netty_tcp_client_address_resolver_seconds_sum{remote_address="localhost:64921",status="SUCCESS"} 1.095592293
reactor_netty_tcp_client_address_resolver_seconds_max{remote_address="localhost:64921",status="SUCCESS"} 0.01396475
reactor_netty_tcp_client_connect_time_seconds_count{proxy_address="na",remote_address="localhost:64921",status="SUCCESS"} 100
reactor_netty_tcp_client_connect_time_seconds_sum{proxy_address="na",remote_address="localhost:64921",status="SUCCESS"} 3.49526084
reactor_netty_tcp_client_connect_time_seconds_max{proxy_address="na",remote_address="localhost:64921",status="SUCCESS"} 0.039677708
reactor_netty_tcp_client_data_received_bytes_count{proxy_address="na",remote_address="localhost:64921",uri="tcp"} 814
reactor_netty_tcp_client_data_received_bytes_sum{proxy_address="na",remote_address="localhost:64921",uri="tcp"} 325900.0
reactor_netty_tcp_client_data_received_bytes_max{proxy_address="na",remote_address="localhost:64921",uri="tcp"} 2048.0
reactor_netty_tcp_client_data_sent_bytes_count{proxy_address="na",remote_address="localhost:64921",uri="tcp"} 1200
reactor_netty_tcp_client_data_sent_bytes_sum{proxy_address="na",remote_address="localhost:64921",uri="tcp"} 108700.0
```