### PR TITLE
use ubuntu-latest

### DIFF
--- a/.github/workflows/ci-graalvm-tests.yml
+++ b/.github/workflows/ci-graalvm-tests.yml
@@ -16,18 +16,18 @@ name: Native Image Build Test
 
 on:
   pull_request:
-    branches: [ "trunk", "0.9.x" ]
+    branches: ["trunk", "0.9.x"]
 
 jobs:
   graalvm-build-pr:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - uses: graalvm/setup-graalvm@v1
         with:
           java-version: 21
-          distribution: 'graalvm'
+          distribution: "graalvm"
           native-image-job-reports: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -43,7 +43,7 @@ jobs:
 
       - name: Build and run native image
         run: |
-            echo "JAVA_HOME=$JAVA_HOME"
-            echo "./mvnw -Pgraalvm package -Dmaven.javadoc.skip=true"
-            ./mvnw -Pgraalvm package -Dmaven.javadoc.skip=true
-            ./test-native-image/target/test-native-image
+          echo "JAVA_HOME=$JAVA_HOME"
+          echo "./mvnw -Pgraalvm package -Dmaven.javadoc.skip=true"
+          ./mvnw -Pgraalvm package -Dmaven.javadoc.skip=true
+          ./test-native-image/target/test-native-image

--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -2,14 +2,15 @@ name: Integration Tests
 
 on:
   pull_request:
-    branches: [ "trunk", "0.9.x" ]
+    branches: ["trunk", "0.9.x"]
 
 jobs:
   integration-tests-pr:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        mysql-version: [ 5.5, 5.6.45, 5.6, 5.7.28, 5.7, 8.0, 8.1, 8.2, 8.3, 8.4, 9.0]
+        mysql-version:
+          [5.5, 5.6.45, 5.6, 5.7.28, 5.7, 8.0, 8.1, 8.2, 8.3, 8.4, 9.0]
     name: Integration test with MySQL ${{ matrix.mysql-version }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-mariadb-intergration-tests.yml
+++ b/.github/workflows/ci-mariadb-intergration-tests.yml
@@ -2,14 +2,15 @@ name: Integration Tests for MariaDB
 
 on:
   pull_request:
-    branches: [ "trunk", "0.9.x" ]
+    branches: ["trunk", "0.9.x"]
 
 jobs:
   mariadb-integration-tests-pr:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        mariadb-version: [ 10.0, 10.1, 10.2.15, 10.2, 10.3.7, 10.3, 10.5.1, 10.5, 10.6, 10.11]
+        mariadb-version:
+          [10.0, 10.1, 10.2.15, 10.2, 10.3.7, 10.3, 10.5.1, 10.5, 10.6, 10.11]
     name: Integration test with MariaDB ${{ matrix.mariadb-version }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-unit-tests.yml
+++ b/.github/workflows/ci-unit-tests.yml
@@ -2,14 +2,14 @@ name: Unit tests
 
 on:
   pull_request:
-    branches: [ "trunk", "0.9.x" ]
+    branches: ["trunk", "0.9.x"]
 
 jobs:
   unit-tests-pr:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [ 8, 11, 17, 21 ]
+        java-version: [8, 11, 17, 21]
     name: linux-java-${{ matrix.java-version }}
     steps:
       - uses: actions/checkout@v3
@@ -20,7 +20,7 @@ jobs:
           java-version: ${{ matrix.java-version }}
           cache: maven
       - name: Unit test with Maven
-        run: | 
+        run: |
           set -o pipefail
           ./mvnw -B test -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN \
           -Dio.netty.leakDetectionLevel=paranoid \


### PR DESCRIPTION
Motivation:
Ubuntu 20.04 runner will be unsupported by april 1.

Modification:
Switched to ubuntu-latest

Result:
Ensure future compatibility.