### PR TITLE
Fix Typo

### DIFF
--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfiguration.java
@@ -418,7 +418,7 @@ public final class MySqlConnectionConfiguration {
                 ", passwordPublisher=" + passwordPublisher +
                 ", resolver=" + resolver +
                 ", metrics=" + metrics +
-                ", tinyint1isBit=" + tinyInt1isBit;
+                ", tinyInt1isBit=" + tinyInt1isBit;
     }
 
     /**


### PR DESCRIPTION
Motiviation:
The `MysqlConnectionConfiguration#toString` has a typo: `tinyint1isBit`.

Modifications:
Corrected the typo to `tinyInt1isBit`.

Result:
Fixed.