### PR TITLE
fix(test): Stringify versions to avoid incorrect Docker tag resolution

### DIFF
--- a/.github/workflows/ci-integration-tests.yml
+++ b/.github/workflows/ci-integration-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         mysql-version:
-          [5.5, 5.6.45, 5.6, 5.7.28, 5.7, 8.0, 8.1, 8.2, 8.3, 8.4, 9.0]
+          ['5.5', '5.6.45', '5.6', '5.7.28', '5.7', '8.0', '8.1', '8.2', '8.3', '8.4', '9.0', '9.1', '9.2']
     name: Integration test with MySQL ${{ matrix.mysql-version }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-mariadb-intergration-tests.yml
+++ b/.github/workflows/ci-mariadb-intergration-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         mariadb-version:
-          [10.0, 10.1, 10.2.15, 10.2, 10.3.7, 10.3, 10.5.1, 10.5, 10.6, 10.11]
+          ['10.0', '10.1', '10.2.15', '10.2', '10.3.7', '10.3', '10.5.1', '10.5', '10.6', '10.11']
     name: Integration test with MariaDB ${{ matrix.mariadb-version }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
motivation:
Numeric version like 5.0 resolve to '5', which pulls the latest 5.x version.
This caused tests to break due to version mismatches.

modifications:
Stringify versions

results:
TestContainer now pulls the correct MySQL image, and tests run reliably.