### PR TITLE
chore(deploy): Migrate from OSSRH to Central Publisher Portal

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -118,9 +118,9 @@ jobs:
         with:
           servers: |
             [{
-              "id": "ossrh-staging",
-              "username": "${{ secrets.OSSRH_USERNAME }}",
-              "password": "${{ secrets.OSSRH_PASSWORD }}"
+              "id": "central",
+              "username": "${{ secrets.CENTRAL_USERNAME }}",
+              "password": "${{ secrets.CENTRAL_PASSWORD }}"
             }]
 
       - name: Create Local Deploy Directory

--- a/.github/workflows/cd-snapshot.yml
+++ b/.github/workflows/cd-snapshot.yml
@@ -46,9 +46,9 @@ jobs:
         with:
           servers: |
             [{
-              "id": "ossrh-snapshots",
-              "username": "${{ secrets.OSSRH_USERNAME }}",
-              "password": "${{ secrets.OSSRH_PASSWORD }}"
+              "id": "central-portal-snapshots",
+              "username": "${{ secrets.CENTRAL_USERNAME }}",
+              "password": "${{ secrets.CENTRAL_PASSWORD }}"
             }]
 
       - name: Prepare Internal Dependencies

--- a/r2dbc-mysql/pom.xml
+++ b/r2dbc-mysql/pom.xml
@@ -448,6 +448,14 @@
           </includes>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.7.0</version>
+        <configuration>
+          <publishingServerId>central</publishingServerId>
+        </configuration>
+      </plugin>
     </plugins>
     <resources>
       <resource>
@@ -558,16 +566,9 @@
   </repositories>
 
   <distributionManagement>
-    <repository>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-      <id>ossrh-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
-    </repository>
+    <snapshotRepository>
+      <id>central-portal-snapshots</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+    </snapshotRepository>
   </distributionManagement>
 </project>


### PR DESCRIPTION
Motivation:
The OSSRH will reach EOL on June 30th, 2025. To continue publishing to Maven Central, migration to the Central Publisher Portal is required.

Modifications:
Migrated the publishing configuration from OSSRH to the Central Publisher Portal.

Results:
Ensured uinterrupted deployments post-OSSRH EOL.