### PR TITLE
fix: tolerate missing auth plugin metadata and non-standard SHOW VARIABLES results

### DIFF
--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/InitFlow.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/InitFlow.java
@@ -222,9 +222,14 @@ final class InitFlow {
             if (value == null || value.isEmpty()) {
                 return data;
             } else {
-                return data.lockWaitTimeout(Duration.ofSeconds(Long.parseLong(value)));
+                try {
+                    return data.lockWaitTimeout(Duration.ofSeconds(Long.parseLong(value)));
+                } catch (NumberFormatException e) {
+                    logger.warn("Unexpected innodb_lock_wait_timeout value '{}', ignoring", value);
+                    return data;
+                }
             }
-        })).single(data).flatMap(d -> {
+        })).last(data).flatMap(d -> {
             if (lockWaitTimeout != null) {
                 // Do not use context.isLockWaitTimeoutSupported() here, because its session variable is not set
                 if (d.lockWaitTimeoutSupported) {

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/message/server/HandshakeV10Request.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/message/server/HandshakeV10Request.java
@@ -163,19 +163,26 @@ final class HandshakeV10Request implements HandshakeRequest, ServerStatusMessage
 
             if (capability.isPluginAuthAllowed()) {
                 // See also MySQL bug 59453, auth type native name has no terminal character in
-                // version less than 5.5.10, or version greater than 5.6.0 and less than 5.6.2
-                // And MySQL only support "mysql_native_password" in those versions that has the
-                // bug, maybe just use constant "mysql_native_password" without read?
+                // version less than 5.5.10, or version greater than 5.6.0 and less than 5.6.2.
+                // Some old or customized MySQL-compatible servers (e.g. pre-5.5.10 forks, certain
+                // proxy layers) advertise PLUGIN_AUTH but leave the auth plugin name empty. In that
+                // case MySQL's own client libraries fall back to mysql_native_password (or
+                // mysql_old_password for pre-4.1 servers) rather than abandoning authentication.
                 int length = buf.bytesBefore(TERMINAL);
 
                 if (length < 0) {
                     builder.authType(buf.toString(StandardCharsets.US_ASCII));
+                } else if (length == 0) {
+                    builder.authType(capability.isSaltSecured() ?
+                        MySqlAuthProvider.MYSQL_NATIVE_PASSWORD :
+                        MySqlAuthProvider.MYSQL_OLD_PASSWORD);
                 } else {
-                    builder.authType(length == 0 ? MySqlAuthProvider.NO_AUTH_PROVIDER :
-                        buf.toString(buf.readerIndex(), length, StandardCharsets.US_ASCII));
+                    builder.authType(buf.toString(buf.readerIndex(), length, StandardCharsets.US_ASCII));
                 }
             } else {
-                builder.authType(MySqlAuthProvider.NO_AUTH_PROVIDER);
+                builder.authType(capability.isSaltSecured() ?
+                    MySqlAuthProvider.MYSQL_NATIVE_PASSWORD :
+                    MySqlAuthProvider.MYSQL_OLD_PASSWORD);
             }
 
             return builder.build();


### PR DESCRIPTION
## Summary

Fix compatibility issues seen with some MySQL-compatible servers and proxy layers during connection handshake and session initialization:
- handshake auth metadata may be missing, empty, or otherwise unusable, which can cause the driver to send no password payload or fail to choose a reasonable auth plugin
- `SHOW VARIABLES LIKE 'innodb_lock_wait_timeout'` may return non-standard results (for example non-numeric values or duplicate rows), which can break connection initialization

## Fix

### Handshake auth fallback

When the server advertises plugin auth but the auth plugin name is empty, fall back to:
- `mysql_native_password` when secure auth / 4.1+ style authentication is negotiated
- `mysql_old_password` for older non-secure cases

Also apply the same fallback when a usable auth plugin is not available from the handshake path, instead of leaving the driver with `NO_AUTH_PROVIDER`.

### Session initialization hardening

For `SHOW VARIABLES LIKE 'innodb_lock_wait_timeout'` handling:
- ignore non-numeric values instead of failing with `NumberFormatException`
- log a warning and keep initialization moving
- use `.last(data)` instead of `.single(data)` so duplicate rows do not fail initialization

## Why this is safe

These changes are intentionally defensive and only affect abnormal / compatibility edge cases:
- if the server provides a valid auth plugin name, the existing path is unchanged
- if `innodb_lock_wait_timeout` is returned normally as a single numeric row, the existing path is unchanged
- the fallback behavior matches what MySQL client implementations typically do in older or partially compatible handshake scenarios
- for duplicated `SHOW VARIABLES` rows, taking the last mapped value is strictly less fragile than failing the entire connection attempt

## Validation

- confirmed the empty/absent auth plugin case from the affected environment
- verified the patched driver can connect through the affected proxy layer
- reproduced both failures in a downstream Spring WebFlux service before the patch
- confirmed the downstream failures map directly to the two code paths changed here
- switched that same downstream service from `io.asyncer:r2dbc-mysql:1.4.1` to `1.4.1-SNAPSHOT` and re-ran the same integration paths against the same environment
- downstream regression results after the version switch:
  - `/dao/memberVip/1234`: `500` before -> `200` after, with a non-empty JSON result returned for `memberAccount=1234`
  - `/dao/orderInfo/1234`: `500` before (`NumberFormatException: "utf8"`) -> `200` after
  - `/dao/channle/1234`: `200` before -> `200` after
  - `/dao/cardInfo/1234`: `200` before -> `200` after
- this gives end-to-end regression coverage across the same four downstream data-access paths used in the service wiring
- CI pending

## Sanitized downstream environment notes

The upstream review probably benefits from knowing the broad server-generation context, but not from exposing internal environment details. So below is the highest-signal sanitized version:

- the `using password: No` failure was reproduced against a MySQL 5.5-compatible endpoint during handshake/authentication
- the `NumberFormatException: For input string: "utf8"` failure was reproduced against a MySQL 5.7-compatible endpoint during session initialization

No hostnames, usernames, project identifiers, internal paths, or trace IDs are included.

## Sanitized downstream stack traces

All environment-specific values below are masked. That includes usernames, client IPs/hosts, internal project paths, and request trace IDs.

### 1. Missing / empty auth plugin -> driver sends no password payload -> server rejects login

Observed behavior in the downstream service:
- the repository call fails while trying to acquire the first R2DBC connection
- the server responds with `using password: No`, which matches the handshake path where auth plugin metadata is missing / empty and the driver ends up sending no password payload

```text
org.springframework.dao.DataAccessResourceFailureException: Failed to obtain R2DBC Connection
    at org.springframework.r2dbc.connection.ConnectionFactoryUtils.lambda$getConnection$0(ConnectionFactoryUtils.java:102)
    ...
Caused by: io.r2dbc.spi.R2dbcPermissionDeniedException: [1045] [28000]
    Access denied for user '<db_user>'@'<client_host>' (using password: No)
    at io.asyncer.r2dbc.mysql.message.server.ErrorMessage.toException(ErrorMessage.java:90)
    at io.asyncer.r2dbc.mysql.HandshakeExchangeable.accept(InitFlow.java:535)
    at io.asyncer.r2dbc.mysql.HandshakeExchangeable.accept(InitFlow.java:478)
    at io.asyncer.r2dbc.mysql.MySqlConnectionFactory.getMySqlConnection(MySqlConnectionFactory.java:151)
    at io.r2dbc.pool.ConnectionPool.createConnectionPool(ConnectionPool.java:263)
    at org.springframework.r2dbc.connection.ConnectionFactoryUtils.doGetConnection(ConnectionFactoryUtils.java:151)
    ...
```

This was reproduced from a real downstream request path and maps directly to the handshake fallback change in this PR.

### 2. Non-standard `SHOW VARIABLES` result -> `NumberFormatException` during session initialization

Observed behavior in the downstream service:
- the handshake completes, but connection initialization fails during session setup
- the server / proxy returns a non-numeric value for the `innodb_lock_wait_timeout` query result
- in the reproduced case the returned value was `utf8`, which caused `Long.parseLong(...)` to fail

```text
org.springframework.dao.DataAccessResourceFailureException: Failed to obtain R2DBC Connection
    at org.springframework.r2dbc.connection.ConnectionFactoryUtils.lambda$getConnection$0(ConnectionFactoryUtils.java:102)
    ...
Caused by: java.lang.NumberFormatException: For input string: "utf8"
    at java.lang.Long.parseLong(Long.java:709)
    at java.lang.Long.parseLong(Long.java:832)
    at io.asyncer.r2dbc.mysql.InitFlow.lambda$null$6(InitFlow.java:222)
    at io.asyncer.r2dbc.mysql.MySqlSegmentResult.lambda$map$2(MySqlSegmentResult.java:109)
    at io.asyncer.r2dbc.mysql.InitFlow.loadAndInitInnoDbEngineStatus(InitFlow.java:224)
    at io.asyncer.r2dbc.mysql.InitFlow.initSession(InitFlow.java:166)
    at io.asyncer.r2dbc.mysql.MySqlConnectionFactory.getMySqlConnection(MySqlConnectionFactory.java:151)
    at io.r2dbc.pool.ConnectionPool.createConnectionPool(ConnectionPool.java:263)
    at org.springframework.r2dbc.connection.ConnectionFactoryUtils.doGetConnection(ConnectionFactoryUtils.java:151)
    ...
```

This maps directly to the session-initialization hardening in this PR: treat malformed values as unusable for this optional initialization step instead of failing the whole connection.

## Notes on duplicate rows

The downstream environment also motivated replacing `.single(data)` with `.last(data)`.

That change is relevant because some proxy / compatibility layers may return more than one row for `SHOW VARIABLES LIKE 'innodb_lock_wait_timeout'`. Even when the values are otherwise usable, `.single(data)` makes initialization unnecessarily brittle by turning duplicated rows into a connection failure.

## Why these traces matter

These are not synthetic failures. They came from an actual downstream application using Spring WebFlux + Spring Data R2DBC against a MySQL-compatible environment. They demonstrate that the issues fixed here are independently reproducible in production-like integration paths:

- one failure happens before authentication can complete because the password payload is effectively omitted
- another happens after handshake, when initialization assumes a numeric single-row `SHOW VARIABLES` result that the server/proxy does not guarantee

That is why this PR handles these cases defensively instead of relying on stricter server behavior.
