### PR TITLE
fix(ci): pin maven-settings-action to v4.0.0

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -114,7 +114,7 @@ jobs:
           restore-keys: ${{ runner.os }}-prepare-
 
       - name: Set Up Maven Settings
-        uses: s4u/maven-settings-action@v4
+        uses: s4u/maven-settings-action@v4.0.0
         with:
           servers: |
             [{

--- a/.github/workflows/cd-snapshot.yml
+++ b/.github/workflows/cd-snapshot.yml
@@ -42,7 +42,7 @@ jobs:
         run: mkdir -p ~/local-staging
 
       - name: Set Up Maven Settings
-        uses: s4u/maven-settings-action@v4
+        uses: s4u/maven-settings-action@v4.0.0
         with:
           servers: |
             [{

--- a/.github/workflows/cd-snapshot.yml
+++ b/.github/workflows/cd-snapshot.yml
@@ -17,6 +17,7 @@ name: DEPLOY_SNAPSHOT
 on:
   push:
     branches: [ "trunk", "0.9.x" ]
+  workflow_dispatch:
 
 
 jobs:


### PR DESCRIPTION
Motivation:
v4 floating tag does not exist in s4u/maven-settings-action. only immutable v4.0.0 tag is published.

Modifications:
Pin both cd-snapshot.yml and cd-release.yml to
s4u/maven-settings-action@v4.0.0.

Results:
Maven settings step resolves successfully on the workflow runner.