### PR TITLE
fix(ssl): disable Netty endpoint identification

### DIFF
--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/client/SslBridgeHandler.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/client/SslBridgeHandler.java
@@ -33,6 +33,7 @@ import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
+import org.jetbrains.annotations.VisibleForTesting;
 import reactor.core.Exceptions;
 import reactor.netty.tcp.SslProvider;
 
@@ -201,7 +202,8 @@ final class SslBridgeHandler extends ChannelDuplexHandler {
             || (version.isGreaterThanOrEqualTo(MYSQL_5_6_0) && version.isEnterprise());
     }
 
-    private static final class MySqlSslContextSpec {
+    @VisibleForTesting
+    static final class MySqlSslContextSpec {
 
         private final SslContextBuilder builder;
 
@@ -218,7 +220,11 @@ final class SslBridgeHandler extends ChannelDuplexHandler {
             SslContextBuilder builder = SslContextBuilder.forClient()
                 .sslProvider(OpenSsl.isAvailable() ? OPENSSL : JDK)
                 .ciphers(null, IdentityCipherSuiteFilter.INSTANCE)
-                .applicationProtocolConfig(null);
+                .applicationProtocolConfig(null)
+                // Netty 4.2 flips the default from null to "HTTPS", which forces hostname verification
+                // during the handshake and would break SslMode.VERIFY_CA. Hostname is checked manually
+                // in handleSslCompleted via the configured HostnameVerifier. Ref: #335.
+                .endpointIdentificationAlgorithm(null);
             String[] tlsProtocols = ssl.getTlsVersion();
 
             if (tlsProtocols.length > 0 || ssl.getSslMode() == SslMode.TUNNEL) {

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfigurationTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/MySqlConnectionConfigurationTest.java
@@ -45,7 +45,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 /**
  * Unit tests for {@link MySqlConnectionConfiguration}.
  */
-class MySqlConnectionConfigurationTest {
+public class MySqlConnectionConfigurationTest {
 
     private static final String HOST = "localhost";
 
@@ -233,6 +233,11 @@ class MySqlConnectionConfigurationTest {
                 .metrics(true)
                 .build()
         );
+    }
+
+    public static MySqlSslConfiguration newSsl(SslMode sslMode) {
+        return MySqlConnectionConfiguration.builder()
+            .host(HOST).user(USER).sslMode(sslMode).build().getSsl();
     }
 
     private static MySqlConnectionConfiguration unixSocketSslMode(SslMode sslMode) {

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/client/SslBridgeHandlerTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/client/SslBridgeHandlerTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql.client;
+
+import io.asyncer.r2dbc.mysql.ConnectionContextTest;
+import io.asyncer.r2dbc.mysql.MySqlConnectionConfigurationTest;
+import io.asyncer.r2dbc.mysql.constant.SslMode;
+import io.netty.buffer.ByteBufAllocator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SslBridgeHandlerTest {
+
+    @ParameterizedTest
+    @EnumSource(value = SslMode.class,
+        names = { "PREFERRED", "REQUIRED", "VERIFY_CA", "VERIFY_IDENTITY", "TUNNEL" })
+    void disablesNettyEndpointIdentification(SslMode mode) throws Exception {
+        assertThat(SslBridgeHandler.MySqlSslContextSpec
+            .forClient(MySqlConnectionConfigurationTest.newSsl(mode), ConnectionContextTest.mock())
+            .sslContext().newEngine(ByteBufAllocator.DEFAULT).getSSLParameters()
+            .getEndpointIdentificationAlgorithm()).isNull();
+    }
+}


### PR DESCRIPTION
Motivation:
Netty 4.2 flips defaults `endpointIdentificationAlgorithm` from `null` to `HTTPS`, which forces hostname verification and breaks `VERIFY_CA`.

Modifications:
Pass `endpointIdentificationAlgorithm(null)` on SslContext.

Results:
`SslMode.VERIFY_CA` keeps working on Netty 4.2.

resolves #335