### PR TITLE
docs: add Spring Boot 4.0 to compatiilbity table

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,16 @@ See [R2DBC MySQL wiki](https://github.com/asyncer-io/r2dbc-mysql/wiki) for more 
 
 ## Spring-framework and R2DBC-SPI Compatibility
 
+`r2dbc-mysql` supports Spring Boot 4.0 (and Spring Framework 7) starting from version `1.4.2`.
+
 Refer to the table below to determine the appropriate version of r2dbc-mysql for your project.
 
-| spring-boot-starter-data-r2dbc | spring-data-r2dbc | r2dbc-spi     | r2dbc-mysql(recommended)     |
-|--------------------------------|-------------------|---------------|------------------------------|
-| 3.0.* and above                | 3.0.* and above   | 1.0.0.RELEASE | io.asyncer:r2dbc-mysql:1.4.0 |
-| 2.7.*                          | 1.5.*             | 0.9.1.RELEASE | io.asyncer:r2dbc-mysql:0.9.7 |
-| 2.6.* and below                | 1.4.* and below   | 0.8.6.RELEASE | dev.miku:r2dbc-mysql:0.8.2   |
+| spring-boot-starter-data-r2dbc  | spring-data-r2dbc       | r2dbc-spi     | r2dbc-mysql(recommended)     |
+|---------------------------------|-------------------------|---------------|------------------------------|
+| 4.0.* and above                 | 4.0.* and above         | 1.0.0.RELEASE | io.asyncer:r2dbc-mysql:1.4.2 |
+| 3.0.* and above                 | 3.0.* and above         | 1.0.0.RELEASE | io.asyncer:r2dbc-mysql:1.4.2 |
+| 2.7.*                           | 1.5.*                   | 0.9.1.RELEASE | io.asyncer:r2dbc-mysql:0.9.7 |
+| 2.6.* and below                 | 1.4.* and below         | 0.8.6.RELEASE | dev.miku:r2dbc-mysql:0.8.2   |
 
 ## Supported Features
 


### PR DESCRIPTION
Motivation:
r2dbc-mysql is compatible with Spring Boot 4.

Modifications:
Add Spring Boot 4 to the compatibilty table.

Results:
Up to date.