### PR TITLE
fix: tolerate missing auth plugin metadata and non-standard SHOW VARIABLES results

### DIFF
--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/InitFlow.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/InitFlow.java
@@ -70,6 +70,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -91,6 +92,8 @@ final class InitFlow {
     private static final ServerVersion MYSQL_5_7_20 = ServerVersion.create(5, 7, 20);
 
     private static final ServerVersion MYSQL_8 = ServerVersion.create(8, 0, 0);
+
+    private static final String INNODB_LOCK_WAIT_TIMEOUT = "innodb_lock_wait_timeout";
 
     private static final BiConsumer<ServerMessage, SynchronousSink<Boolean>> INIT_DB = (message, sink) -> {
         if (message instanceof ErrorMessage) {
@@ -216,15 +219,10 @@ final class InitFlow {
             client,
             codecs,
             "SHOW VARIABLES LIKE 'innodb_lock_wait_timeout'"
-        ).execute().flatMap(r -> r.map(readable -> {
-            String value = readable.get(1, String.class);
-
-            if (value == null || value.isEmpty()) {
-                return data;
-            } else {
-                return data.lockWaitTimeout(Duration.ofSeconds(Long.parseLong(value)));
-            }
-        })).single(data).flatMap(d -> {
+        ).execute().flatMap(r -> r.map(InitFlow::readInnoDbLockWaitTimeout)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .map(data::lockWaitTimeout)).last(data).flatMap(d -> {
             if (lockWaitTimeout != null) {
                 // Do not use context.isLockWaitTimeoutSupported() here, because its session variable is not set
                 if (d.lockWaitTimeoutSupported) {
@@ -237,6 +235,27 @@ final class InitFlow {
             }
             return Mono.just(d);
         });
+    }
+
+    static Optional<Duration> readInnoDbLockWaitTimeout(Readable readable) {
+        String name = readable.get(0, String.class);
+
+        if (!INNODB_LOCK_WAIT_TIMEOUT.equalsIgnoreCase(name)) {
+            return Optional.empty();
+        }
+
+        String value = readable.get(1, String.class);
+
+        if (value == null || value.isEmpty()) {
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.of(Duration.ofSeconds(Long.parseLong(value)));
+        } catch (NumberFormatException e) {
+            logger.warn("Unexpected innodb_lock_wait_timeout value '{}', ignoring", value);
+            return Optional.empty();
+        }
     }
 
     private static Mono<SessionState> loadSessionVariables(Client client, Codecs codecs) {

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/message/client/HandshakeResponse41.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/message/client/HandshakeResponse41.java
@@ -111,6 +111,8 @@ final class HandshakeResponse41 extends ScalarClientMessage implements Handshake
 
         if (capability.isVarIntSizedAuthAllowed()) {
             writeVarIntSizedBytes(buf, authentication);
+        } else if (!capability.isSaltSecured()) {
+            buf.writeBytes(authentication).writeByte(0);
         } else if (authentication.length <= ONE_BYTE_MAX_INT) {
             buf.writeByte(authentication.length).writeBytes(authentication);
         } else {

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/message/server/HandshakeV10Request.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/message/server/HandshakeV10Request.java
@@ -163,19 +163,26 @@ final class HandshakeV10Request implements HandshakeRequest, ServerStatusMessage
 
             if (capability.isPluginAuthAllowed()) {
                 // See also MySQL bug 59453, auth type native name has no terminal character in
-                // version less than 5.5.10, or version greater than 5.6.0 and less than 5.6.2
-                // And MySQL only support "mysql_native_password" in those versions that has the
-                // bug, maybe just use constant "mysql_native_password" without read?
+                // version less than 5.5.10, or version greater than 5.6.0 and less than 5.6.2.
+                // Some old or customized MySQL-compatible servers (e.g. pre-5.5.10 forks, certain
+                // proxy layers) advertise PLUGIN_AUTH but leave the auth plugin name empty. In that
+                // case MySQL's own client libraries fall back to mysql_native_password (or
+                // mysql_old_password for pre-4.1 servers) rather than abandoning authentication.
                 int length = buf.bytesBefore(TERMINAL);
 
                 if (length < 0) {
                     builder.authType(buf.toString(StandardCharsets.US_ASCII));
+                } else if (length == 0) {
+                    builder.authType(capability.isSaltSecured() ?
+                        MySqlAuthProvider.MYSQL_NATIVE_PASSWORD :
+                        MySqlAuthProvider.MYSQL_OLD_PASSWORD);
                 } else {
-                    builder.authType(length == 0 ? MySqlAuthProvider.NO_AUTH_PROVIDER :
-                        buf.toString(buf.readerIndex(), length, StandardCharsets.US_ASCII));
+                    builder.authType(buf.toString(buf.readerIndex(), length, StandardCharsets.US_ASCII));
                 }
             } else {
-                builder.authType(MySqlAuthProvider.NO_AUTH_PROVIDER);
+                builder.authType(capability.isSaltSecured() ?
+                    MySqlAuthProvider.MYSQL_NATIVE_PASSWORD :
+                    MySqlAuthProvider.MYSQL_OLD_PASSWORD);
             }
 
             return builder.build();

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/InitFlowTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/InitFlowTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql;
+
+import io.r2dbc.spi.Readable;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link InitFlow}.
+ */
+class InitFlowTest {
+
+    @Test
+    void readInnoDbLockWaitTimeout() {
+        Optional<Duration> actual = InitFlow.readInnoDbLockWaitTimeout(row(
+            "innodb_lock_wait_timeout", "5"));
+
+        assertThat(actual).hasValue(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void ignoreUnrelatedVariableRows() {
+        Optional<Duration> actual = InitFlow.readInnoDbLockWaitTimeout(row(
+            "character_set_client", "utf8"));
+
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
+    void ignoreMalformedLockWaitTimeout() {
+        Optional<Duration> actual = InitFlow.readInnoDbLockWaitTimeout(row(
+            "innodb_lock_wait_timeout", "utf8"));
+
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
+    void ignoreEmptyLockWaitTimeout() {
+        Optional<Duration> actual = InitFlow.readInnoDbLockWaitTimeout(row(
+            "innodb_lock_wait_timeout", ""));
+
+        assertThat(actual).isEmpty();
+    }
+
+    private static Readable row(String name, String value) {
+        Readable readable = mock(Readable.class);
+
+        when(readable.get(0, String.class)).thenReturn(name);
+        when(readable.get(1, String.class)).thenReturn(value);
+
+        return readable;
+    }
+}

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/message/client/HandshakeResponse41Test.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/message/client/HandshakeResponse41Test.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql.message.client;
+
+import io.asyncer.r2dbc.mysql.Capability;
+import io.asyncer.r2dbc.mysql.ConnectionContextTest;
+import io.asyncer.r2dbc.mysql.authentication.MySqlAuthProvider;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link HandshakeResponse41}.
+ */
+class HandshakeResponse41Test {
+
+    private static final int SSL_REQUEST_41_SIZE = 32;
+
+    @Test
+    void writeNullTerminatedAuthForNonSecureConnection() {
+        byte[] authentication = "scramble".getBytes(StandardCharsets.US_ASCII);
+        HandshakeResponse41 response = new HandshakeResponse41(
+            Capability.of(0x271F), 45, "user", authentication, MySqlAuthProvider.MYSQL_OLD_PASSWORD,
+            "", Collections.emptyMap(), 0);
+        ByteBuf buf = response.encode(UnpooledByteBufAllocator.DEFAULT, ConnectionContextTest.mock()).block();
+
+        try {
+            buf.skipBytes(SSL_REQUEST_41_SIZE);
+            skipCString(buf);
+
+            byte[] actual = new byte[authentication.length];
+            buf.readBytes(actual);
+
+            assertThat(actual).isEqualTo(authentication);
+            assertThat(buf.readByte()).isZero();
+        } finally {
+            buf.release();
+        }
+    }
+
+    private static void skipCString(ByteBuf buf) {
+        int length = buf.bytesBefore((byte) 0);
+
+        buf.skipBytes(length + 1);
+    }
+}

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/message/server/HandshakeV10RequestTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/message/server/HandshakeV10RequestTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql.message.server;
+
+import io.asyncer.r2dbc.mysql.Capability;
+import io.asyncer.r2dbc.mysql.authentication.MySqlAuthProvider;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link HandshakeV10Request}.
+ */
+class HandshakeV10RequestTest {
+
+    @Test
+    void fallbackToNativePasswordWhenPluginAuthIsNotAdvertised() {
+        HandshakeRequest request = HandshakeRequest.decode(handshake(0xA71F, ""));
+
+        assertThat(request.getServerCapability().isSaltSecured()).isTrue();
+        assertThat(request.getServerCapability().isPluginAuthAllowed()).isFalse();
+        assertThat(request.getAuthType()).isEqualTo(MySqlAuthProvider.MYSQL_NATIVE_PASSWORD);
+    }
+
+    @Test
+    void fallbackToNativePasswordWhenPluginAuthNameIsEmpty() {
+        HandshakeRequest request = HandshakeRequest.decode(handshake(0x8A71F, ""));
+
+        assertThat(request.getServerCapability().isSaltSecured()).isTrue();
+        assertThat(request.getServerCapability().isPluginAuthAllowed()).isTrue();
+        assertThat(request.getAuthType()).isEqualTo(MySqlAuthProvider.MYSQL_NATIVE_PASSWORD);
+    }
+
+    @Test
+    void fallbackToOldPasswordWhenSecureConnectionIsNotAdvertised() {
+        HandshakeRequest request = HandshakeRequest.decode(handshake(0x271F, ""));
+
+        assertThat(request.getServerCapability().isSaltSecured()).isFalse();
+        assertThat(request.getServerCapability().isPluginAuthAllowed()).isFalse();
+        assertThat(request.getAuthType()).isEqualTo(MySqlAuthProvider.MYSQL_OLD_PASSWORD);
+    }
+
+    @Test
+    void readAdvertisedAuthPluginName() {
+        HandshakeRequest request = HandshakeRequest.decode(handshake(
+            0x8A71F, MySqlAuthProvider.MYSQL_NATIVE_PASSWORD));
+
+        assertThat(request.getAuthType()).isEqualTo(MySqlAuthProvider.MYSQL_NATIVE_PASSWORD);
+    }
+
+    private static ByteBuf handshake(long capability, String authType) {
+        ByteBuf buf = Unpooled.buffer();
+
+        buf.writeByte(10);
+        writeCString(buf, "5.5.2");
+        buf.writeIntLE(1);
+        buf.writeBytes("12345678".getBytes(StandardCharsets.US_ASCII));
+        buf.writeByte(0);
+        buf.writeShortLE((int) (capability & 0xFFFF));
+        buf.writeByte(45);
+        buf.writeShortLE(2);
+        buf.writeShortLE((int) ((capability >>> Short.SIZE) & 0xFFFF));
+        buf.writeByte(21);
+        buf.writeZero(10);
+
+        if (Capability.of(capability).isSaltSecured()) {
+            buf.writeBytes("abcdefghijkl".getBytes(StandardCharsets.US_ASCII));
+            buf.writeByte(0);
+        }
+
+        writeCString(buf, authType);
+
+        return buf;
+    }
+
+    private static void writeCString(ByteBuf buf, String value) {
+        buf.writeBytes(value.getBytes(StandardCharsets.US_ASCII));
+        buf.writeByte(0);
+    }
+}


### PR DESCRIPTION
> Re-submission of #336. The previous head fork was deleted, so GitHub could not reopen it. This PR carries the same fix, rebased and squashed.

## Summary

Fix two connection-initialization compatibility failures seen with MySQL-compatible servers and proxy layers:

- empty or missing auth-plugin metadata can make the driver choose an unusable auth path and fail login with `1045 / 28000 ... using password: No`
- non-standard `SHOW VARIABLES LIKE 'innodb_lock_wait_timeout'` results can fail session initialization with `NumberFormatException`, e.g. `For input string: "utf8"`

## Background

These failures were reproduced from a downstream Spring WebFlux + Spring Data R2DBC application using vanilla `io.asyncer:r2dbc-mysql:1.4.1`.

The affected environments are sanitized below, but the server versions, driver versions, capability/auth behavior, exception classes, and exception messages are kept as observed.

| Endpoint | Server `VERSION()` | Vanilla `1.4.1` failure | This PR |
|---|---:|---|---|
| A | `5.7.30-log` | `NumberFormatException: For input string: "utf8"` during `InitFlow.loadAndInitInnoDbEngineStatus` | OK |
| B | `5.5.2` | empty auth plugin path leads to `1045 / 28000 ... using password: No` | OK |

## Changes

- Fall back to `mysql_native_password` when secure auth is available, or `mysql_old_password` otherwise, if the handshake plugin name is empty or not advertised.
- For `innodb_lock_wait_timeout`, only consume rows whose `Variable_name` exactly matches `innodb_lock_wait_timeout`.
- Ignore empty or non-numeric target values, and use the last valid target row instead of requiring a single row.
- Add unit coverage for the auth fallback and variable parsing edge cases.

## Why this is safe

These changes are defensive and limited to abnormal compatibility cases:

- valid advertised auth plugin names keep the existing path
- normal single-row numeric `innodb_lock_wait_timeout` responses keep the same effective behavior
- empty/missing auth metadata now follows the older MySQL-compatible fallback path instead of leaving the driver on an unusable provider
- noisy or duplicate `SHOW VARIABLES` rows no longer fail the whole connection, and unrelated rows cannot overwrite the parsed target value

## Key traces

### Empty / missing auth plugin

The server side rejects login with `using password: No`, consistent with the driver selecting an unusable auth path after receiving empty auth-plugin metadata.

```text
org.springframework.dao.DataAccessResourceFailureException: Failed to obtain R2DBC Connection
    at org.springframework.r2dbc.connection.ConnectionFactoryUtils.lambda$getConnection$0(ConnectionFactoryUtils.java:102)
    ...
Caused by: io.r2dbc.spi.R2dbcPermissionDeniedException: [1045] [28000]
    Access denied for user '<db_user>'@'<client_host>' (using password: No)
    at io.asyncer.r2dbc.mysql.message.server.ErrorMessage.toException(ErrorMessage.java:90)
    at io.asyncer.r2dbc.mysql.HandshakeExchangeable.accept(InitFlow.java:535)
    at io.asyncer.r2dbc.mysql.MySqlConnectionFactory.getMySqlConnection(MySqlConnectionFactory.java:151)
    at io.r2dbc.pool.ConnectionPool.createConnectionPool(ConnectionPool.java:263)
    ...
```

Observed handshake shape:

```text
HandshakeV10Request{..., serverVersion=5.5.2, serverCapability=Capability<0xa71f>, authType=''}
HandshakeResponse41{..., authType='caching_sha2_password', ...}
ErrorMessage{code=1045, sqlState='28000', message='Access denied ... (using password: No)'}
```

### Non-standard `SHOW VARIABLES` result

The handshake succeeds, then session initialization fails because the response value is not numeric.

```text
org.springframework.dao.DataAccessResourceFailureException: Failed to obtain R2DBC Connection
    at org.springframework.r2dbc.connection.ConnectionFactoryUtils.lambda$getConnection$0(ConnectionFactoryUtils.java:102)
    ...
Caused by: java.lang.NumberFormatException: For input string: "utf8"
    at java.lang.Long.parseLong(Long.java:709)
    at java.lang.Long.parseLong(Long.java:832)
    at io.asyncer.r2dbc.mysql.InitFlow.lambda$null$6(InitFlow.java:222)
    at io.asyncer.r2dbc.mysql.MySqlSegmentResult.lambda$map$2(MySqlSegmentResult.java:109)
    at io.asyncer.r2dbc.mysql.InitFlow.loadAndInitInnoDbEngineStatus(InitFlow.java:224)
    at io.asyncer.r2dbc.mysql.MySqlConnectionFactory.getMySqlConnection(MySqlConnectionFactory.java:151)
    ...
```

The non-obvious part is that endpoint A does not return a single row for:

```sql
SHOW VARIABLES LIKE 'innodb_lock_wait_timeout'
```

It returns about 30 rows, including unrelated values such as `character_set_client=utf8`, `tx_isolation=READ-COMMITTED`, and the real `innodb_lock_wait_timeout=5` row among them. That is why the fix filters for the exact target variable before parsing, and initializes `lockWaitTimeout=PT5S` from the matching row.

## Validation

Against this PR head (rebuilt locally as `1.4.2-SNAPSHOT`):

| Endpoint | Result |
|---|---|
| A | OK: `SELECT 1`, `SELECT VERSION()`, `SHOW VARIABLES LIKE 'innodb_lock_wait_timeout'`, and `R2dbcEntityTemplate SELECT 1` all pass |
| B | OK: same probe passes |

Additional checks:

- Endpoint A initializes `lockWaitTimeout=PT5S` from the exact `innodb_lock_wait_timeout=5` row despite the noisy response.
- `./mvnw -pl r2dbc-mysql -Dtest=InitFlowTest,HandshakeV10RequestTest test` passes: 8 tests.
- DCO is passing on the current head; no other GitHub checks are reported at this moment.

All hostnames, IPs, schema names, usernames, client hosts, and internal paths are intentionally omitted.
