### PR TITLE
Fix legacy authentication and lock timeout parsing

### DIFF
--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/InitFlow.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/InitFlow.java
@@ -92,6 +92,8 @@ final class InitFlow {
 
     private static final ServerVersion MYSQL_8 = ServerVersion.create(8, 0, 0);
 
+    private static final Duration DEFAULT_LOCK_WAIT_TIMEOUT = Duration.ofSeconds(50);
+
     private static final BiConsumer<ServerMessage, SynchronousSink<Boolean>> INIT_DB = (message, sink) -> {
         if (message instanceof ErrorMessage) {
             ErrorMessage msg = (ErrorMessage) message;
@@ -222,7 +224,7 @@ final class InitFlow {
             if (value == null || value.isEmpty()) {
                 return data;
             } else {
-                return data.lockWaitTimeout(Duration.ofSeconds(Long.parseLong(value)));
+                return data.lockWaitTimeout(parseLockWaitTimeout(value));
             }
         })).single(data).flatMap(d -> {
             if (lockWaitTimeout != null) {
@@ -237,6 +239,16 @@ final class InitFlow {
             }
             return Mono.just(d);
         });
+    }
+
+    static Duration parseLockWaitTimeout(String value) {
+        try {
+            return Duration.ofSeconds(Long.parseLong(value.trim()));
+        } catch (NumberFormatException e) {
+            logger.warn("Lock wait timeout {} is not a number, fallback to {} seconds",
+                value, DEFAULT_LOCK_WAIT_TIMEOUT.getSeconds());
+            return DEFAULT_LOCK_WAIT_TIMEOUT;
+        }
     }
 
     private static Mono<SessionState> loadSessionVariables(Client client, Codecs codecs) {

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/message/server/HandshakeV10Request.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/message/server/HandshakeV10Request.java
@@ -175,7 +175,9 @@ final class HandshakeV10Request implements HandshakeRequest, ServerStatusMessage
                         buf.toString(buf.readerIndex(), length, StandardCharsets.US_ASCII));
                 }
             } else {
-                builder.authType(MySqlAuthProvider.NO_AUTH_PROVIDER);
+                builder.authType(capability.isSaltSecured() ?
+                    MySqlAuthProvider.MYSQL_NATIVE_PASSWORD :
+                    MySqlAuthProvider.NO_AUTH_PROVIDER);
             }
 
             return builder.build();

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/InitFlowTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/InitFlowTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link InitFlow}.
+ */
+class InitFlowTest {
+
+    @Test
+    void parseStringLockWaitTimeout() {
+        assertThat(InitFlow.parseLockWaitTimeout(" 30 ")).isEqualTo(Duration.ofSeconds(30));
+    }
+
+    @Test
+    void fallbackForMalformedLockWaitTimeout() {
+        assertThat(InitFlow.parseLockWaitTimeout("not-a-number")).isEqualTo(Duration.ofSeconds(50));
+    }
+}

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/message/server/HandshakeV10RequestTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/message/server/HandshakeV10RequestTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql.message.server;
+
+import io.asyncer.r2dbc.mysql.Capability;
+import io.asyncer.r2dbc.mysql.authentication.MySqlAuthProvider;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link HandshakeV10Request}.
+ */
+class HandshakeV10RequestTest {
+
+    @Test
+    void fallbackToNativePasswordWithoutPluginAuth() {
+        HandshakeRequest request = HandshakeRequest.decode(handshakeWithoutPluginAuth());
+
+        assertThat(request.getServerCapability().isSaltSecured()).isTrue();
+        assertThat(request.getServerCapability().isPluginAuthAllowed()).isFalse();
+        assertThat(request.getAuthType()).isEqualTo(MySqlAuthProvider.MYSQL_NATIVE_PASSWORD);
+    }
+
+    private static ByteBuf handshakeWithoutPluginAuth() {
+        long capability = 0xA71F;
+        ByteBuf buf = Unpooled.buffer();
+
+        buf.writeByte(10);
+        writeCString(buf, "5.5.2");
+        buf.writeIntLE(1);
+        buf.writeBytes("12345678".getBytes(StandardCharsets.US_ASCII));
+        buf.writeByte(0);
+        buf.writeShortLE((int) (capability & 0xFFFF));
+        buf.writeByte(45);
+        buf.writeShortLE(2);
+        buf.writeShortLE((int) ((capability >>> Short.SIZE) & 0xFFFF));
+        buf.writeByte(21);
+        buf.writeZero(10);
+        buf.writeBytes("abcdefghijkl".getBytes(StandardCharsets.US_ASCII));
+        buf.writeByte(0);
+
+        return buf;
+    }
+
+    private static void writeCString(ByteBuf buf, String value) {
+        buf.writeBytes(value.getBytes(StandardCharsets.US_ASCII));
+        buf.writeByte(0);
+    }
+}


### PR DESCRIPTION
Motivation:

Some MySQL-compatible proxy layers expose two legacy compatibility behaviors during connection initialization:

1. The server advertises `CLIENT_SECURE_CONNECTION` and provides a full authentication salt, but does not advertise `CLIENT_PLUGIN_AUTH`. The current fallback selects `NO_AUTH_PROVIDER`, so the handshake response contains an empty password and the server rejects it with `using password: No`.
2. The server reports `innodb_lock_wait_timeout` as a string-like value. Current `trunk` already reads this result as `String`; parsing it defensively prevents a malformed proxy response from aborting the whole connection initialization.

This is a deliberately narrower resubmission of #344. It contains only the two behaviors carried by a downstream `1.1.2-SNAPSHOT` patch that has since been deployed and verified with production traffic.

Modification:

- When `CLIENT_PLUGIN_AUTH` is absent, fall back to `mysql_native_password` only if `CLIENT_SECURE_CONNECTION` confirms that the secure salt is available.
- Keep `NO_AUTH_PROVIDER` for the non-secure legacy path.
- Trim and parse the string lock-wait-timeout value, falling back to MySQL's default of 50 seconds when it is not numeric.
- Add focused unit tests for both compatibility paths.

No other authentication or result-row behavior is changed. In particular, this does not add the previous proposal's `mysql_old_password` fallback, unrelated-row filtering, or duplicate-row handling.

Result:

- Existing servers that advertise a valid authentication plugin are unaffected.
- Servers without plugin-auth metadata can still authenticate with `mysql_native_password` when secure authentication data is present.
- Normal numeric lock-wait-timeout values retain their existing behavior; malformed values no longer fail connection initialization.
- The equivalent downstream patch has been running successfully in production against the affected proxy.
- Focused tests pass on Java 8 and Java 21:

  ```text
  ./mvnw -pl r2dbc-mysql -Dtest=InitFlowTest,HandshakeV10RequestTest test
  Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
  ```

Local full unit execution ran 443 tests: 442 passed, while the repository's existing `TestServerUtilTest` could not initialize because Docker was not running locally. GitHub CI can run the complete Java 8/11/17/21 matrix.
