### PR TITLE
Fix cancellation race during connection acquisition

### DIFF
--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/QueryFlow.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/QueryFlow.java
@@ -432,7 +432,9 @@ final class SimpleQueryExchangeable extends BaseFluxExchangeable {
                 return;
             }
 
-            QueryFlow.logger.error("Emit request failed due to {}", result);
+            if (result != Sinks.EmitResult.FAIL_CANCELLED) {
+                QueryFlow.logger.error("Emit request failed due to {}", result);
+            }
         }
 
         if (sink != null) {

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/client/ReactorNettyClient.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/client/ReactorNettyClient.java
@@ -179,33 +179,59 @@ final class ReactorNettyClient implements Client {
     public <T> Flux<T> exchange(FluxExchangeable<T> exchangeable) {
         requireNonNull(exchangeable, "exchangeable must not be null");
 
-        return Mono.<Flux<T>>create(sink -> {
+        return Flux.defer(() -> {
             if (!isConnected()) {
                 exchangeable.subscribe(request -> {
                     if (request instanceof Disposable) {
                         ((Disposable) request).dispose();
                     }
                 }, e -> requests.emitError(e, Sinks.EmitFailureHandler.FAIL_FAST));
-                sink.error(ClientExceptions.exchangeClosed());
-                return;
+                return Flux.error(ClientExceptions.exchangeClosed());
             }
 
+            Sinks.Empty<Void> cancellationSignal = Sinks.empty(); // tracks if we should stop sending requests
+            Sinks.Empty<Void> noRequestSignal = Sinks.empty(); // tracks if we need to await a response (for a request)
+            Flux<ClientMessage> outbound = exchangeable
+                .takeUntilOther(cancellationSignal.asMono())
+                .doOnError(e -> requests.emitError(e, Sinks.EmitFailureHandler.FAIL_FAST))
+                .switchOnFirst((signal, requests) -> {
+                    if (!signal.hasValue()) {
+                        // source closed without emitting any elements at all
+                        Throwable error = signal.getThrowable();
+                        if (error == null) {
+                            noRequestSignal.tryEmitEmpty();
+                        } else {
+                            noRequestSignal.tryEmitError(error);
+                        }
+                    }
+
+                    return requests;
+                });
             Flux<T> responses = responseProcessor
                 .asFlux()
-                .doOnSubscribe(ignored -> exchangeable.subscribe(
-                    this::emitNextRequest,
-                    e -> requests.emitError(e, Sinks.EmitFailureHandler.FAIL_FAST)
-                ))
+                .takeUntilOther(noRequestSignal.asMono())
+                .doOnSubscribe(ignored -> outbound.subscribe(this::emitNextRequest, e -> { }))
                 .handle(exchangeable)
                 .doOnTerminate(() -> {
                     exchangeable.dispose();
                     requestQueue.run();
                 });
 
-            requestQueue.submit(RequestTask.wrap(exchangeable, sink, OperatorUtils.discardOnCancel(responses)
+            Mono<Void> acquire = Mono.<Void>create(sink ->
+                requestQueue.submit(RequestTask.wrap(sink, null))
+            )
+                .doOnError(ignored -> exchangeable.dispose());
+
+            return OperatorUtils.discardOnCancel(acquire.thenMany(responses))
                 .doOnDiscard(ReferenceCounted.class, ReferenceCounted::release)
-                .doOnCancel(exchangeable::dispose)));
-        }).flatMapMany(Function.identity());
+                .doOnCancel(() -> {
+                    try {
+                        exchangeable.dispose();
+                    } finally {
+                        cancellationSignal.tryEmitEmpty();
+                    }
+                });
+        });
     }
 
     @Override

--- a/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/client/RequestTask.java
+++ b/r2dbc-mysql/src/main/java/io/asyncer/r2dbc/mysql/client/RequestTask.java
@@ -19,7 +19,6 @@ package io.asyncer.r2dbc.mysql.client;
 import io.asyncer.r2dbc.mysql.message.client.ClientMessage;
 import org.jetbrains.annotations.Nullable;
 import reactor.core.Disposable;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.MonoSink;
 
 /**
@@ -83,33 +82,9 @@ final class RequestTask<T> {
         return task;
     }
 
-    static <T> RequestTask<T> wrap(Flux<? extends ClientMessage> messages, MonoSink<T> sink, T supplier) {
-        final RequestTask<T> task =  new RequestTask<>(new DisposableFlux(messages), sink, supplier);
-        sink.onCancel(task::cancel0);
-        return task;
-    }
-
     static <T> RequestTask<T> wrap(MonoSink<T> sink, T supplier) {
         final RequestTask<T> task = new RequestTask<>(null, sink, supplier);
         sink.onCancel(task::cancel0);
         return task;
-    }
-
-    private static final class DisposableFlux implements Disposable {
-
-        private final Flux<? extends ClientMessage> messages;
-
-        private DisposableFlux(Flux<? extends ClientMessage> messages) {
-            this.messages = messages;
-        }
-
-        @Override
-        public void dispose() {
-            Flux.from(messages).subscribe(it -> {
-                if (it instanceof Disposable) {
-                    ((Disposable) it).dispose();
-                }
-            });
-        }
     }
 }

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/ExchangeableTestSupport.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/ExchangeableTestSupport.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql;
+
+import io.asyncer.r2dbc.mysql.client.FluxExchangeable;
+import io.asyncer.r2dbc.mysql.message.server.ServerMessage;
+
+/**
+ * Exposes package-private {@link FluxExchangeable} implementations to tests in other packages.
+ */
+public final class ExchangeableTestSupport {
+
+    public static FluxExchangeable<ServerMessage> simpleQuery(String sql) {
+        return new SimpleQueryExchangeable(sql);
+    }
+
+    private ExchangeableTestSupport() {
+    }
+}

--- a/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/client/ReactorNettyClientTest.java
+++ b/r2dbc-mysql/src/test/java/io/asyncer/r2dbc/mysql/client/ReactorNettyClientTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2026 asyncer.io projects
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.asyncer.r2dbc.mysql.client;
+
+import io.asyncer.r2dbc.mysql.ConnectionContextTest;
+import io.asyncer.r2dbc.mysql.ExchangeableTestSupport;
+import io.asyncer.r2dbc.mysql.MySqlConnectionConfigurationTest;
+import io.asyncer.r2dbc.mysql.constant.SslMode;
+import io.asyncer.r2dbc.mysql.message.client.ClientMessage;
+import io.asyncer.r2dbc.mysql.message.client.PingMessage;
+import io.asyncer.r2dbc.mysql.message.server.CompleteMessage;
+import io.asyncer.r2dbc.mysql.message.server.ServerMessage;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.core.publisher.SynchronousSink;
+import reactor.netty.Connection;
+import reactor.netty.NettyInbound;
+import reactor.netty.NettyOutbound;
+import reactor.test.StepVerifier;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ReactorNettyClient}.
+ */
+class ReactorNettyClientTest {
+
+    private static final CompleteMessage DONE = () -> true;
+
+    private final Sinks.Many<Object> inbound = Sinks.many().unicast().onBackpressureBuffer();
+
+    private final AtomicInteger sent = new AtomicInteger();
+
+    private volatile CompletableFuture<Void> responseGate = CompletableFuture.completedFuture(null);
+
+    private ExecutorService server;
+
+    private EmbeddedChannel channel;
+
+    private ReactorNettyClient client;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void startFakeServer() {
+        server = Executors.newSingleThreadExecutor(r -> new Thread(r, "fake-server"));
+
+        channel = new EmbeddedChannel();
+        Connection connection = mock(Connection.class);
+        NettyInbound nettyInbound = mock(NettyInbound.class);
+        NettyOutbound nettyOutbound = mock(NettyOutbound.class);
+
+        when(connection.channel()).thenReturn(channel);
+        when(connection.addHandlerLast(any(String.class), any())).thenReturn(connection);
+        when(connection.inbound()).thenReturn(nettyInbound);
+        doReturn(inbound.asFlux()).when(nettyInbound).receiveObject();
+        when(connection.outbound()).thenReturn(nettyOutbound);
+        when(nettyOutbound.sendObject(any(ClientMessage.class))).thenAnswer(invocation -> {
+            sent.incrementAndGet();
+            responseGate.thenRunAsync(() ->
+                inbound.emitNext(DONE, Sinks.EmitFailureHandler.FAIL_FAST), server);
+            return nettyOutbound;
+        });
+        doAnswer(invocation -> {
+            Mono.<Void>empty().subscribe(invocation.<Subscriber<Void>>getArgument(0));
+            return null;
+        }).when(nettyOutbound).subscribe(any());
+
+        client = new ReactorNettyClient(connection,
+            MySqlConnectionConfigurationTest.newSsl(SslMode.DISABLED), ConnectionContextTest.mock());
+    }
+
+    @AfterEach
+    void stopServer() {
+        server.shutdownNow();
+        channel.finishAndReleaseAll();
+    }
+
+    /**
+     * Cancels a subscribed query after a random amount of yields to try and trigger a race which could cause
+     * connections to be unusable.
+     * Runs 5000 times since it's a non-deterministic race.
+     */
+    @Test
+    void cancellingExchangeDuringStartupDoesNotStallRequestQueue() throws Exception {
+        ExecutorService canceller = Executors.newSingleThreadExecutor(r -> new Thread(r, "canceller"));
+        try {
+            for (int i = 0; i < 5_000; i++) {
+                CompletableFuture<Subscription> subscription = new CompletableFuture<>();
+                long yields = ThreadLocalRandom.current().nextLong(400);
+
+                Flux<ServerMessage> query = client.exchange(ExchangeableTestSupport.simpleQuery("SELECT 1"))
+                    .doOnSubscribe(subscription::complete);
+
+                Future<?> cancellation = canceller.submit(() -> {
+                    for (long j = 0; j < yields; j++) {
+                        Thread.yield();
+                    }
+
+                    subscription.get(2, TimeUnit.SECONDS).cancel();
+                    return null;
+                });
+
+                query.subscribe();
+                cancellation.get(2, TimeUnit.SECONDS);
+
+                assertQueryCompletes(i + 1);
+            }
+        } finally {
+            canceller.shutdownNow();
+        }
+    }
+
+    @Test
+    void subscribedToInboundFirst() {
+        CompletableFuture<Void> responses = pauseResponses();
+        ServerFirstExchangeable exchangeable = new ServerFirstExchangeable();
+
+        StepVerifier.create(client.exchange(exchangeable))
+            .then(() -> {
+                assertThat(sent).hasValue(0);
+                inbound.emitNext(DONE, Sinks.EmitFailureHandler.FAIL_FAST);
+                responses.complete(null);
+            })
+            .expectComplete()
+            .verify(Duration.ofSeconds(2));
+
+        assertThat(sent).hasValue(1);
+    }
+
+    @Test
+    void cancellingQueuedExchangeDisposesItImmediately() {
+        CompletableFuture<Void> responses = pauseResponses();
+        DisposableExchangeable exchangeable = new DisposableExchangeable();
+
+        StepVerifier.create(client.exchange(ExchangeableTestSupport.simpleQuery("SELECT 1")).then())
+            .then(() -> {
+                assertThat(sent).hasValue(1);
+                client.exchange(exchangeable).subscribe().dispose();
+                assertThat(exchangeable.isDisposed()).isTrue();
+                responses.complete(null);
+            })
+            .expectComplete()
+            .verify(Duration.ofSeconds(2));
+
+        StepVerifier.create(client.exchange(ExchangeableTestSupport.simpleQuery("SELECT 1")).then())
+            .expectComplete()
+            .verify(Duration.ofSeconds(2));
+    }
+
+    private void assertQueryCompletes(int iteration) {
+        assertThatCode(() -> client.exchange(ExchangeableTestSupport.simpleQuery("SELECT 1"))
+            .then()
+            .block(Duration.ofSeconds(2)))
+            .as("probe query after cancellation %s; sent=%s", iteration, sent)
+            .doesNotThrowAnyException();
+    }
+
+    private CompletableFuture<Void> pauseResponses() {
+        CompletableFuture<Void> responses = new CompletableFuture<>();
+        responseGate = responses;
+        return responses;
+    }
+
+    private static final class ServerFirstExchangeable extends FluxExchangeable<Void> {
+
+        private final Sinks.Many<ClientMessage> requests = Sinks.many().unicast().onBackpressureBuffer();
+
+        private final AtomicBoolean started = new AtomicBoolean();
+
+        @Override
+        public void subscribe(CoreSubscriber<? super ClientMessage> actual) {
+            requests.asFlux().subscribe(actual);
+        }
+
+        @Override
+        public void accept(ServerMessage message, SynchronousSink<Void> sink) {
+            if (started.compareAndSet(false, true)) {
+                requests.emitNext(PingMessage.INSTANCE, Sinks.EmitFailureHandler.FAIL_FAST);
+            } else {
+                sink.complete();
+            }
+        }
+
+        @Override
+        public void dispose() {
+            requests.tryEmitComplete();
+        }
+    }
+
+    private static final class DisposableExchangeable extends FluxExchangeable<Void> {
+
+        private final AtomicBoolean disposed = new AtomicBoolean();
+
+        @Override
+        public void subscribe(CoreSubscriber<? super ClientMessage> actual) {
+            Flux.<ClientMessage>never().subscribe(actual);
+        }
+
+        @Override
+        public void accept(ServerMessage message, SynchronousSink<Void> sink) {
+            sink.error(new AssertionError("Unexpected response"));
+        }
+
+        @Override
+        public void dispose() {
+            disposed.set(true);
+        }
+
+        @Override
+        public boolean isDisposed() {
+            return disposed.get();
+        }
+    }
+}


### PR DESCRIPTION
**Motivation**:
We're seeing the cancellation exhaustion issue described in #347, which we're trying to fix.

**Modification**:
This change now ensures that cancellation causes no more requests to be sent along to the server. In cases where some requests have already been sent, it ensures that they're still consumed and the requestQueue is executed.

To achieve this, we use Flux's takeUntilOther on both outgoing and incoming Fluxes (with slightly different "marker" sinks):
* We cut off the outgoing (messages sent to the server) stream when cancellation is requested.
* We stop processing incoming messages if no outgoing messages have been produced (i.e., the stream has been cancelled, or it errored). If any messages have been produced (switchOnFirst -> signal.hasValue()), we do not stop this processing anymore and let the discard take its course.


Finally, this adds tests around a bunch of scenarios wrt cancellations. There were no previous tests for ReactorNettyClient so I wasn't sure what kind of mocking would be expected for network interactions - hopefully this virtual server provides a good start.

**Result**:
Fixes #347.